### PR TITLE
upstream-contrib: Show last CI build artifact 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Android CI
+name: GithubActions CI
 
 on: [push, workflow_dispatch]
 
@@ -7,6 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+
     - name: Setup JDK 11
       uses: actions/setup-java@v3
       with:
@@ -44,3 +45,25 @@ jobs:
         name: outputs-lint
         path: app/build/reports/lint-*
 
+  pre-release:
+    if: (github.ref == 'refs/heads/master' || contains(github.ref, 'refs/tags/'))
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+    - name: Retrieve built assets
+      uses: actions/download-artifact@v3
+      with:
+        name: outputs-apk
+        path: app/build/outputs/apk
+    - name: Publish assets
+      # Pre-release the built apps and expose it via a static and public accessible URL
+      # Note that this step exists since artifacts (actions/upload-artifact) are neither
+      # public-accessible nor at a constant/static URL
+      # For the pre-releasing purpose, a floating tag is used and re-positioned to the tip of the branch
+      uses: pyTooling/Actions/releaser@r0
+      with:
+        tag: pre-release
+        token: ${{ secrets.GITHUB_TOKEN }}
+        rm: true # clean past assets
+        files: |
+          app/build/outputs/apk/**/*.apk

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Dynamic badge based on https://shields.io/endpoint (the badge service) and https
 store scraper)
 See https://github.com/badges/shields/issues/358#issuecomment-806235967
 -->
-[![Get it on Google Play]](https://img.shields.io/endpoint?color=green&logo=google-play&logoColor=lightgrey&url=https%3A%2F%2Fplay.cuzi.workers.dev%2Fplay%3Fi%3Dcom.poupa.vinylmusicplayer%26l%3DGoogle%2520Play%2520Store%26m%3D%24version)
+[![Get it on Google Play](https://img.shields.io/endpoint?color=green&logo=google-play&logoColor=lightgrey&url=https%3A%2F%2Fplay.cuzi.workers.dev%2Fplay%3Fi%3Dcom.poupa.vinylmusicplayer%26l%3DGoogle%2520Play%2520Store%26m%3D%24version)]
 (https://play.google.com/store/apps/details?id=com.poupa.vinylmusicplayer)
 
 **A material designed local music player for Android.**

--- a/README.md
+++ b/README.md
@@ -1,11 +1,24 @@
 # Vinyl Music Player
-[![License: GPL v3](https://img.shields.io/badge/License-GPL%20v3-blue.svg)](https://github.com/VinylMusicPlayer/VinylMusicPlayer/blob/master/LICENSE.txt) 
-[![GithubActions CI](https://github.com/VinylMusicPlayer/VinylMusicPlayer/actions/workflows/ci.yml/badge.svg)](https://github.com/VinylMusicPlayer/VinylMusicPlayer/actions/workflows/ci.yml)
 
-[![Download](https://img.shields.io/badge/Download-@pre--release-green)](https://github.com/VinylMusicPlayer/VinylMusicPlayer/releases/tag/pre-release)
-<a href="https://f-droid.org/packages/com.poupa.vinylmusicplayer/" target="_blank">
-<img src="https://f-droid.org/badge/get-it-on.png" alt="Get it on F-Droid" height="90"/></a>
-<a href='https://play.google.com/store/apps/details?id=com.poupa.vinylmusicplayer'><img alt='Get it on Google Play' src='https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png' height="90"/></a>
+[![License: GPL v3](https://img.shields.io/badge/License-GPL%20v3-blue.svg)]
+(https://github.com/VinylMusicPlayer/VinylMusicPlayer/blob/master/LICENSE.txt)
+
+[![GithubActions CI](https://github.com/VinylMusicPlayer/VinylMusicPlayer/actions/workflows/ci.yml/badge.svg)]
+(https://github.com/VinylMusicPlayer/VinylMusicPlayer/actions/workflows/ci.yml)
+
+[![Download](https://img.shields.io/badge/Download-@pre--release-brightgreen)]
+(https://github.com/VinylMusicPlayer/VinylMusicPlayer/releases/tag/pre-release)
+
+[![Get it on F-Droid](https://img.shields.io/f-droid/v/com.poupa.vinylmusicplayer)]
+(https://f-droid.org/packages/com.poupa.vinylmusicplayer/)
+
+<!--
+Dynamic badge based on https://shields.io/endpoint (the badge service) and https://play.cuzi.workers.dev/ (play 
+store scraper)
+See https://github.com/badges/shields/issues/358#issuecomment-806235967
+-->
+[![Get it on Google Play]](https://img.shields.io/endpoint?color=green&logo=google-play&logoColor=lightgrey&url=https%3A%2F%2Fplay.cuzi.workers.dev%2Fplay%3Fi%3Dcom.poupa.vinylmusicplayer%26l%3DGoogle%2520Play%2520Store%26m%3D%24version)
+(https://play.google.com/store/apps/details?id=com.poupa.vinylmusicplayer)
 
 **A material designed local music player for Android.**
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 [![GithubActions CI](https://github.com/VinylMusicPlayer/VinylMusicPlayer/actions/workflows/ci.yml/badge.svg)](https://github.com/VinylMusicPlayer/VinylMusicPlayer/actions/workflows/ci.yml)
 
-[![Get it on Github](https://img.shields.io/badge/Download_from_Github-pre--release-brightgreen?logo=github)](https://github.com/VinylMusicPlayer/VinylMusicPlayer/releases/tag/pre-release)
-[![Get it on F-Droid](https://img.shields.io/f-droid/v/com.poupa.vinylmusicplayer?logo=f-droid)](https://f-droid.org/packages/com.poupa.vinylmusicplayer/)
-[![Get it on Google Play](https://img.shields.io/endpoint?color=green&logo=google-play&logoColor=lightgrey&url=https%3A%2F%2Fplay.cuzi.workers.dev%2Fplay%3Fi%3Dcom.poupa.vinylmusicplayer%26l%3DGoogle%2520Play%2520Store%26m%3D%24version)](https://play.google.com/store/apps/details?id=com.poupa.vinylmusicplayer)
+[![Get it on Github](https://img.shields.io/badge/Download_from_Github-pre--release-brightgreen?logo=github&logoColor=lightgrey)](https://github.com/VinylMusicPlayer/VinylMusicPlayer/releases/tag/pre-release)
+[![Get it on F-Droid](https://img.shields.io/f-droid/v/com.poupa.vinylmusicplayer?color=brightgreen&logo=f-droid&logoColor=lightgrey)](https://f-droid.org/packages/com.poupa.vinylmusicplayer/)
+[![Get it on Google Play](https://img.shields.io/endpoint?color=brightgreen&logo=google-play&logoColor=lightgrey&url=https%3A%2F%2Fplay.cuzi.workers.dev%2Fplay%3Fi%3Dcom.poupa.vinylmusicplayer%26l%3DGoogle%2520Play%2520Store%26m%3D%24version)](https://play.google.com/store/apps/details?id=com.poupa.vinylmusicplayer)
 <!--
 Above: Dynamic badge based on https://shields.io/endpoint (the badge service) and https://play.cuzi.workers.dev/ (play 
 store scraper)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
 # Vinyl Music Player
 [![License: GPL v3](https://img.shields.io/badge/License-GPL%20v3-blue.svg)](https://github.com/VinylMusicPlayer/VinylMusicPlayer/blob/master/LICENSE.txt) 
 [![GithubActions CI](https://github.com/VinylMusicPlayer/VinylMusicPlayer/actions/workflows/ci.yml/badge.svg)](https://github.com/VinylMusicPlayer/VinylMusicPlayer/actions/workflows/ci.yml)
+
 [![Download](https://img.shields.io/badge/Download-@pre--release-green)](https://github.com/vinyl2-team/vinyl2/releases/tag/pre-release)
+<a href="https://f-droid.org/packages/com.poupa.vinylmusicplayer/" target="_blank">
+<img src="https://f-droid.org/badge/get-it-on.png" alt="Get it on F-Droid" height="90"/></a>
+<a href='https://play.google.com/store/apps/details?id=com.poupa.vinylmusicplayer'><img alt='Get it on Google Play' src='https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png' height="90"/></a>
 
 **A material designed local music player for Android.**
 

--- a/README.md
+++ b/README.md
@@ -1,24 +1,19 @@
 # Vinyl Music Player
 
-[![License: GPL v3](https://img.shields.io/badge/License-GPL%20v3-blue.svg)]
-(https://github.com/VinylMusicPlayer/VinylMusicPlayer/blob/master/LICENSE.txt)
+[![License: GPL v3](https://img.shields.io/badge/License-GPL%20v3-blue.svg)](https://github.com/VinylMusicPlayer/VinylMusicPlayer/blob/master/LICENSE.txt)
 
-[![GithubActions CI](https://github.com/VinylMusicPlayer/VinylMusicPlayer/actions/workflows/ci.yml/badge.svg)]
-(https://github.com/VinylMusicPlayer/VinylMusicPlayer/actions/workflows/ci.yml)
+[![GithubActions CI](https://github.com/VinylMusicPlayer/VinylMusicPlayer/actions/workflows/ci.yml/badge.svg)](https://github.com/VinylMusicPlayer/VinylMusicPlayer/actions/workflows/ci.yml)
 
-[![Download](https://img.shields.io/badge/Download-@pre--release-brightgreen)]
-(https://github.com/VinylMusicPlayer/VinylMusicPlayer/releases/tag/pre-release)
+[![Download](https://img.shields.io/badge/Download-@pre--release-brightgreen)](https://github.com/VinylMusicPlayer/VinylMusicPlayer/releases/tag/pre-release)
 
-[![Get it on F-Droid](https://img.shields.io/f-droid/v/com.poupa.vinylmusicplayer)]
-(https://f-droid.org/packages/com.poupa.vinylmusicplayer/)
+[![Get it on F-Droid](https://img.shields.io/f-droid/v/com.poupa.vinylmusicplayer)](https://f-droid.org/packages/com.poupa.vinylmusicplayer/)
 
 <!--
 Dynamic badge based on https://shields.io/endpoint (the badge service) and https://play.cuzi.workers.dev/ (play 
 store scraper)
 See https://github.com/badges/shields/issues/358#issuecomment-806235967
 -->
-[![Get it on Google Play](https://img.shields.io/endpoint?color=green&logo=google-play&logoColor=lightgrey&url=https%3A%2F%2Fplay.cuzi.workers.dev%2Fplay%3Fi%3Dcom.poupa.vinylmusicplayer%26l%3DGoogle%2520Play%2520Store%26m%3D%24version)]
-(https://play.google.com/store/apps/details?id=com.poupa.vinylmusicplayer)
+[![Get it on Google Play](https://img.shields.io/endpoint?color=green&logo=google-play&logoColor=lightgrey&url=https%3A%2F%2Fplay.cuzi.workers.dev%2Fplay%3Fi%3Dcom.poupa.vinylmusicplayer%26l%3DGoogle%2520Play%2520Store%26m%3D%24version)](https://play.google.com/store/apps/details?id=com.poupa.vinylmusicplayer)
 
 **A material designed local music player for Android.**
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,7 @@
 # Vinyl Music Player
 [![License: GPL v3](https://img.shields.io/badge/License-GPL%20v3-blue.svg)](https://github.com/VinylMusicPlayer/VinylMusicPlayer/blob/master/LICENSE.txt) 
-[![Android CI](https://github.com/VinylMusicPlayer/VinylMusicPlayer/actions/workflows/ci.yml/badge.svg)](https://github.com/VinylMusicPlayer/VinylMusicPlayer/actions/workflows/ci.yml)
-
-<a href="https://f-droid.org/packages/com.poupa.vinylmusicplayer/" target="_blank">
-<img src="https://f-droid.org/badge/get-it-on.png" alt="Get it on F-Droid" height="90"/></a>
-<a href='https://play.google.com/store/apps/details?id=com.poupa.vinylmusicplayer'><img alt='Get it on Google Play' src='https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png' height="90"/></a>
+[![GithubActions CI](https://github.com/VinylMusicPlayer/VinylMusicPlayer/actions/workflows/ci.yml/badge.svg)](https://github.com/VinylMusicPlayer/VinylMusicPlayer/actions/workflows/ci.yml)
+[![Download](https://img.shields.io/badge/Download-@pre--release-green)](https://github.com/vinyl2-team/vinyl2/releases/tag/pre-release)
 
 **A material designed local music player for Android.**
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![License: GPL v3](https://img.shields.io/badge/License-GPL%20v3-blue.svg)](https://github.com/VinylMusicPlayer/VinylMusicPlayer/blob/master/LICENSE.txt) 
 [![GithubActions CI](https://github.com/VinylMusicPlayer/VinylMusicPlayer/actions/workflows/ci.yml/badge.svg)](https://github.com/VinylMusicPlayer/VinylMusicPlayer/actions/workflows/ci.yml)
 
-[![Download](https://img.shields.io/badge/Download-@pre--release-green)](https://github.com/vinyl2-team/vinyl2/releases/tag/pre-release)
+[![Download](https://img.shields.io/badge/Download-@pre--release-green)](https://github.com/VinylMusicPlayer/VinylMusicPlayer/releases/tag/pre-release)
 <a href="https://f-droid.org/packages/com.poupa.vinylmusicplayer/" target="_blank">
 <img src="https://f-droid.org/badge/get-it-on.png" alt="Get it on F-Droid" height="90"/></a>
 <a href='https://play.google.com/store/apps/details?id=com.poupa.vinylmusicplayer'><img alt='Get it on Google Play' src='https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png' height="90"/></a>
@@ -15,7 +15,7 @@ Additional features:
 * Android Auto support
 * ReplayGain
 * SD Card write access
-* [...and more!](https://github.com/AdrienPoupa/VinylMusicPlayer/blob/master/CHANGELOG.md)
+* [...and more!](https://github.com/VinylMusicPlayer/VinylMusicPlayer/blob/master/CHANGELOG.md)
 
 ![Screenshots](./art/art.png?raw=true)
 

--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@
 
 [![GithubActions CI](https://github.com/VinylMusicPlayer/VinylMusicPlayer/actions/workflows/ci.yml/badge.svg)](https://github.com/VinylMusicPlayer/VinylMusicPlayer/actions/workflows/ci.yml)
 
-[![Download](https://img.shields.io/badge/Download-@pre--release-brightgreen)](https://github.com/VinylMusicPlayer/VinylMusicPlayer/releases/tag/pre-release)
-[![Get it on F-Droid](https://img.shields.io/f-droid/v/com.poupa.vinylmusicplayer)](https://f-droid.org/packages/com.poupa.vinylmusicplayer/)
+[![Get it on Github](https://img.shields.io/badge/Download_from_Github-pre--release-brightgreen?logo=github)](https://github.com/VinylMusicPlayer/VinylMusicPlayer/releases/tag/pre-release)
+[![Get it on F-Droid](https://img.shields.io/f-droid/v/com.poupa.vinylmusicplayer?logo=f-droid)](https://f-droid.org/packages/com.poupa.vinylmusicplayer/)
+[![Get it on Google Play](https://img.shields.io/endpoint?color=green&logo=google-play&logoColor=lightgrey&url=https%3A%2F%2Fplay.cuzi.workers.dev%2Fplay%3Fi%3Dcom.poupa.vinylmusicplayer%26l%3DGoogle%2520Play%2520Store%26m%3D%24version)](https://play.google.com/store/apps/details?id=com.poupa.vinylmusicplayer)
 <!--
-Dynamic badge based on https://shields.io/endpoint (the badge service) and https://play.cuzi.workers.dev/ (play 
+Above: Dynamic badge based on https://shields.io/endpoint (the badge service) and https://play.cuzi.workers.dev/ (play 
 store scraper)
 See https://github.com/badges/shields/issues/358#issuecomment-806235967
 -->
-[![Get it on Google Play](https://img.shields.io/endpoint?color=green&logo=google-play&logoColor=lightgrey&url=https%3A%2F%2Fplay.cuzi.workers.dev%2Fplay%3Fi%3Dcom.poupa.vinylmusicplayer%26l%3DGoogle%2520Play%2520Store%26m%3D%24version)](https://play.google.com/store/apps/details?id=com.poupa.vinylmusicplayer)
 
 **A material designed local music player for Android.**
 

--- a/README.md
+++ b/README.md
@@ -5,9 +5,7 @@
 [![GithubActions CI](https://github.com/VinylMusicPlayer/VinylMusicPlayer/actions/workflows/ci.yml/badge.svg)](https://github.com/VinylMusicPlayer/VinylMusicPlayer/actions/workflows/ci.yml)
 
 [![Download](https://img.shields.io/badge/Download-@pre--release-brightgreen)](https://github.com/VinylMusicPlayer/VinylMusicPlayer/releases/tag/pre-release)
-
 [![Get it on F-Droid](https://img.shields.io/f-droid/v/com.poupa.vinylmusicplayer)](https://f-droid.org/packages/com.poupa.vinylmusicplayer/)
-
 <!--
 Dynamic badge based on https://shields.io/endpoint (the badge service) and https://play.cuzi.workers.dev/ (play 
 store scraper)


### PR DESCRIPTION
- Promote the last build APK from master to a public accessible download link in README.md
  Behind the scenes, this relies on a moving `pre-release` tag, updated each time there is a sucessful build; and on the Github's release facility.
- Replace "Get it on ..." image links by dynamic badges showing the available version on the respective distribution channel.
  See demo: https://github.com/VinylMusicPlayer/VinylMusicPlayer/tree/upstream-contrib/ci-show-last-build-arrifact
