### PR TITLE
Refactor Skipped songs implementation

### DIFF
--- a/app/src/main/java/com/poupa/vinylmusicplayer/adapter/song/PlayingQueueAdapter.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/adapter/song/PlayingQueueAdapter.java
@@ -309,7 +309,7 @@ public class PlayingQueueAdapter extends SongAdapter
             //If playing and currently playing song is removed, then added back, then play it at
             //current song progress
             if (isPlayingSongToRemove) {
-                MusicPlayerRemote.playSongAt(position);
+                MusicPlayerRemote.playSongAt(position, false);
             }
         });
         snackbar.setActionTextColor(getBackgroundColor(activity));

--- a/app/src/main/java/com/poupa/vinylmusicplayer/dialogs/DeleteSongsDialog.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/dialogs/DeleteSongsDialog.java
@@ -76,7 +76,7 @@ public class DeleteSongsDialog extends DialogFragment {
                 .onPositive((dialog, which) -> {
                     // If song removed was the playing song, then play the next song
                     if ((songs.size() == 1) && MusicPlayerRemote.isPlaying(songs.get(0))) {
-                        MusicPlayerRemote.playNextSong();
+                        MusicPlayerRemote.playNextSong(false);
                     }
 
                     // Now remove the track in background
@@ -92,7 +92,6 @@ public class DeleteSongsDialog extends DialogFragment {
         MusicUtil.deleteTracks(getActivity(), songs, safUris, this::dismiss);
     }
 
-    @TargetApi(Build.VERSION_CODES.KITKAT)
     private void deleteSongsKitkat() {
         if (songsToRemove.size() < 1) {
             dismiss();

--- a/app/src/main/java/com/poupa/vinylmusicplayer/helper/MusicPlayerRemote.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/helper/MusicPlayerRemote.java
@@ -123,9 +123,9 @@ public class MusicPlayerRemote {
     /**
      * Async
      */
-    public static void playSongAt(final int position) {
+    public static void playSongAt(final int position, boolean skippedLast) {
         if (musicService != null) {
-            musicService.playSongAt(position);
+            musicService.playSongAt(position, skippedLast);
         }
     }
 
@@ -147,27 +147,27 @@ public class MusicPlayerRemote {
     /**
      * Async
      */
-    public static void playNextSong() {
+    public static void playNextSong(boolean skippedLast) {
         if (musicService != null) {
-            musicService.playNextSong(true);
+            musicService.playNextSong(skippedLast);
         }
     }
 
     /**
      * Async
      */
-    public static void playPreviousSong() {
+    public static void playPreviousSong(boolean skippedLast) {
         if (musicService != null) {
-            musicService.playPreviousSong(true);
+            musicService.playPreviousSong(skippedLast);
         }
     }
 
     /**
      * Async
      */
-    public static void back() {
+    public static void back(boolean skippedLast) {
         if (musicService != null) {
-            musicService.back(true);
+            musicService.back(skippedLast);
         }
     }
 
@@ -314,11 +314,8 @@ public class MusicPlayerRemote {
 
     private static boolean tryToHandleOpenPlayingQueue(final ArrayList<Song> queue, final int startPosition, final boolean startPlaying) {
         if (getPlayingQueue() == queue) {
-            if (startPlaying) {
-                playSongAt(startPosition);
-            } else {
-                setPosition(startPosition);
-            }
+            if (startPlaying) {playSongAt(startPosition, false);}
+            else {setPosition(startPosition);}
             return true;
         }
         return false;

--- a/app/src/main/java/com/poupa/vinylmusicplayer/helper/MusicPlayerRemote.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/helper/MusicPlayerRemote.java
@@ -314,7 +314,7 @@ public class MusicPlayerRemote {
 
     private static boolean tryToHandleOpenPlayingQueue(final ArrayList<Song> queue, final int startPosition, final boolean startPlaying) {
         if (getPlayingQueue() == queue) {
-            if (startPlaying) {playSongAt(startPosition, true);}
+            if (startPlaying) {playSongAt(startPosition, isPlaying());}
             else {setPosition(startPosition);}
             return true;
         }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/helper/MusicPlayerRemote.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/helper/MusicPlayerRemote.java
@@ -79,7 +79,7 @@ public class MusicPlayerRemote {
             return;
         }
         mContextWrapper.unbindService(mBinder);
-        if (mConnectionMap.isEmpty()) {
+        if (mConnectionMap.isEmpty() && musicService != null) {
             if (!musicService.isPlaying()) {
                 musicService.quit();
             }
@@ -314,7 +314,7 @@ public class MusicPlayerRemote {
 
     private static boolean tryToHandleOpenPlayingQueue(final ArrayList<Song> queue, final int startPosition, final boolean startPlaying) {
         if (getPlayingQueue() == queue) {
-            if (startPlaying) {playSongAt(startPosition, false);}
+            if (startPlaying) {playSongAt(startPosition, true);}
             else {setPosition(startPosition);}
             return true;
         }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/helper/PrevNextButtonOnTouchListener.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/helper/PrevNextButtonOnTouchListener.java
@@ -10,7 +10,7 @@ public class PrevNextButtonOnTouchListener implements View.OnTouchListener {
     private static final int SKIP_TRIGGER_INITIAL_INTERVAL_MILLIS = 1000;
     private static final int SKIP_TRIGGER_NORMAL_INTERVAL_MILLIS = 250;
 
-    private final int PLAYBACK_SKIP_AMOUNT_MILLI = 3500;
+    private static final int PLAYBACK_SKIP_AMOUNT_MILLI = 3500;
 
     private final View.OnGenericMotionListener genericMotionListener;
     private View touchedView;

--- a/app/src/main/java/com/poupa/vinylmusicplayer/helper/PrevNextButtonOnTouchListener.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/helper/PrevNextButtonOnTouchListener.java
@@ -52,9 +52,9 @@ public class PrevNextButtonOnTouchListener implements View.OnTouchListener {
                             return true;
                         case MotionEvent.ACTION_CANCEL:
                             if (direction ==  DIRECTION_NEXT) {
-                                MusicPlayerRemote.playNextSong();
+                                MusicPlayerRemote.playNextSong(true);
                             } else if (direction ==  DIRECTION_PREVIOUS) {
-                                MusicPlayerRemote.back();
+                                MusicPlayerRemote.back(true);
                             }
                             return true;
                     }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/misc/queue/StaticPlayingQueue.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/misc/queue/StaticPlayingQueue.java
@@ -380,7 +380,7 @@ public class StaticPlayingQueue {
         return getCurrentPosition() == queue.size() - 1;
     }
 
-    public int getNextPosition(boolean force) {
+    public int getNextPosition(boolean skippedLast) {
         int position = getCurrentPosition() + 1;
         switch (getRepeatMode()) {
             case REPEAT_MODE_ALL:
@@ -389,7 +389,7 @@ public class StaticPlayingQueue {
                 }
                 break;
             case REPEAT_MODE_THIS:
-                if (force) {
+                if (skippedLast) {
                     if (isLastTrack()) {
                         position = 0;
                     }
@@ -407,7 +407,7 @@ public class StaticPlayingQueue {
         return position;
     }
 
-    public int getPreviousPosition(boolean force) {
+    public int getPreviousPosition(boolean skippedLast) {
         int newPosition = getCurrentPosition() - 1;
         switch (repeatMode) {
             case REPEAT_MODE_ALL:
@@ -416,7 +416,7 @@ public class StaticPlayingQueue {
                 }
                 break;
             case REPEAT_MODE_THIS:
-                if (force) {
+                if (skippedLast) {
                     if (newPosition < 0) {
                         newPosition = queue.size() - 1;
                     }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/service/MusicService.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/service/MusicService.java
@@ -824,7 +824,10 @@ public class MusicService extends MediaBrowserServiceCompat implements SharedPre
         if (skippedLast && PreferenceUtil.getInstance().maintainSkippedSongsPlaylist()) {
             // Mark the current song as skipped
             final long playlistId = MusicUtil.getOrCreateSkippedPlaylist(this).id;
-            PlaylistsUtil.addToPlaylist(this, getCurrentSong(), playlistId, true);
+            final Song song = getCurrentSong();
+            if (!PlaylistsUtil.doesPlaylistContain(this, playlistId, song.id)) {
+                PlaylistsUtil.addToPlaylist(this, song, playlistId, true);
+            }
         }
 
         // handle this on the handlers thread to avoid blocking the ui thread

--- a/app/src/main/java/com/poupa/vinylmusicplayer/service/MusicService.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/service/MusicService.java
@@ -662,7 +662,7 @@ public class MusicService extends MediaBrowserServiceCompat implements SharedPre
     }
 
     public Song getCurrentSong() {
-        return (Song)getCurrentIndexedSong();
+        return getCurrentIndexedSong();
     }
 
     public IndexedSong getCurrentIndexedSong() {
@@ -670,7 +670,7 @@ public class MusicService extends MediaBrowserServiceCompat implements SharedPre
     }
 
     public Song getSongAt(int position) {
-        return (Song)getIndexedSongAt(position);
+        return getIndexedSongAt(position);
     }
 
     public IndexedSong getIndexedSongAt(int position) {
@@ -823,9 +823,6 @@ public class MusicService extends MediaBrowserServiceCompat implements SharedPre
     public void playSongAt(final int position, boolean skippedLast) {
         if (skippedLast && PreferenceUtil.getInstance().maintainSkippedSongsPlaylist()) {
             // Mark the current song as skipped
-            // TODO From time to time, recycle the Skipped songs playlist
-            // Otherwise the add/remove operation moght take long time (seconds)
-
             final long playlistId = MusicUtil.getOrCreateSkippedPlaylist(this).id;
             PlaylistsUtil.addToPlaylist(this, getCurrentSong(), playlistId, true);
         }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/fragments/player/AbsPlayerFragment.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/fragments/player/AbsPlayerFragment.java
@@ -125,7 +125,7 @@ public abstract class AbsPlayerFragment extends AbsMusicServiceFragment implemen
             SongShareDialog.create(song).show(getParentFragmentManager(), "SHARE_SONG");
             return true;
         } else if (itemId == R.id.action_equalizer) {
-            NavigationUtil.openEqualizer(getActivity());
+            NavigationUtil.openEqualizer(requireActivity());
             return true;
         } else if (itemId == R.id.action_add_to_playlist) {
             AddToPlaylistDialog.create(song).show(getParentFragmentManager(), "ADD_PLAYLIST");
@@ -134,10 +134,10 @@ public abstract class AbsPlayerFragment extends AbsMusicServiceFragment implemen
             MusicPlayerRemote.clearQueue();
             return true;
         } else if (itemId == R.id.action_save_playing_queue) {
-            CreatePlaylistDialog.create(MusicPlayerRemote.getPlayingQueue()).show(getActivity().getSupportFragmentManager(), "ADD_TO_PLAYLIST");
+            CreatePlaylistDialog.create(MusicPlayerRemote.getPlayingQueue()).show(requireActivity().getSupportFragmentManager(), "ADD_TO_PLAYLIST");
             return true;
         } else if (itemId == R.id.action_tag_editor) {
-            Intent intent = new Intent(getActivity(), SongTagEditorActivity.class);
+            Intent intent = new Intent(requireActivity(), SongTagEditorActivity.class);
             intent.putExtra(AbsTagEditorActivity.EXTRA_ID, song.id);
             startActivity(intent);
             return true;
@@ -145,17 +145,17 @@ public abstract class AbsPlayerFragment extends AbsMusicServiceFragment implemen
             SongDetailDialog.create(song).show(getParentFragmentManager(), "SONG_DETAIL");
             return true;
         } else if (itemId == R.id.action_go_to_album) {
-            NavigationUtil.goToAlbum(getActivity(), song.albumId);
+            NavigationUtil.goToAlbum(requireActivity(), song.albumId);
             return true;
         } else if (itemId == R.id.action_go_to_artist) {
-            NavigationUtil.goToArtist(getActivity(), song.artistId);
+            NavigationUtil.goToArtist(requireActivity(), song.artistId);
             return true;
         }
         return false;
     }
 
     protected void toggleFavorite(Song song) {
-        MusicUtil.toggleFavorite(getActivity(), song);
+        MusicUtil.toggleFavorite(requireActivity(), song);
     }
 
     protected boolean isToolbarShown() {
@@ -203,7 +203,7 @@ public abstract class AbsPlayerFragment extends AbsMusicServiceFragment implemen
 
     protected boolean hasEqualizer() {
         final Intent effects = new Intent(AudioEffect.ACTION_DISPLAY_AUDIO_EFFECT_CONTROL_PANEL);
-        PackageManager pm = getActivity().getPackageManager();
+        PackageManager pm = requireActivity().getPackageManager();
         ResolveInfo ri = pm.resolveActivity(effects, 0);
         return ri != null;
     }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/fragments/player/AbsPlayerFragment.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/fragments/player/AbsPlayerFragment.java
@@ -42,15 +42,13 @@ public abstract class AbsPlayerFragment extends AbsMusicServiceFragment implemen
 
     private Callbacks callbacks;
     private static boolean isToolbarShown = true;
-
     protected Toolbar toolbar;
 
-    public PlayingQueueAdapter playingQueueAdapter;
-    public RecyclerView.Adapter wrappedAdapter;
-    public RecyclerViewDragDropManager recyclerViewDragDropManager;
-    public RecyclerViewSwipeManager recyclerViewSwipeManager;
-    public RecyclerViewTouchActionGuardManager recyclerViewTouchActionGuardManager;
-    public LinearLayoutManager layoutManager;
+    protected PlayingQueueAdapter playingQueueAdapter;
+    private RecyclerView.Adapter wrappedAdapter;
+    protected RecyclerViewDragDropManager recyclerViewDragDropManager;
+    private RecyclerViewSwipeManager recyclerViewSwipeManager;
+    protected LinearLayoutManager layoutManager;
 
     @Override
     public void onAttach(@NonNull Context context) {
@@ -69,7 +67,7 @@ public abstract class AbsPlayerFragment extends AbsMusicServiceFragment implemen
     }
 
     public void setUpRecyclerView(RecyclerView recyclerView, final SlidingUpPanelLayout slidingUpPanelLayout) {
-        recyclerViewTouchActionGuardManager = new RecyclerViewTouchActionGuardManager();
+        RecyclerViewTouchActionGuardManager recyclerViewTouchActionGuardManager = new RecyclerViewTouchActionGuardManager();
         recyclerViewSwipeManager = new RecyclerViewSwipeManager();
         recyclerViewDragDropManager = new RecyclerViewDragDropManager();
 

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/fragments/player/MiniPlayerFragment.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/fragments/player/MiniPlayerFragment.java
@@ -129,10 +129,10 @@ public class MiniPlayerFragment extends AbsMusicServiceFragment implements Music
                 public boolean onFling(MotionEvent e1, MotionEvent e2, float velocityX, float velocityY) {
                     if (Math.abs(velocityX) > Math.abs(velocityY)) {
                         if (velocityX < 0) {
-                            MusicPlayerRemote.playNextSong();
+                            MusicPlayerRemote.playNextSong(true);
                             return true;
                         } else if (velocityX > 0) {
-                            MusicPlayerRemote.playPreviousSong();
+                            MusicPlayerRemote.playPreviousSong(true);
                             return true;
                         }
                     }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/fragments/player/PlayerAlbumCoverFragment.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/fragments/player/PlayerAlbumCoverFragment.java
@@ -121,7 +121,7 @@ public class PlayerAlbumCoverFragment extends AbsMusicServiceFragment implements
         currentPosition = position;
         ((AlbumCoverPagerAdapter) viewPager.getAdapter()).receiveColor(colorReceiver, position);
         if (position != MusicPlayerRemote.getPosition()) {
-            MusicPlayerRemote.playSongAt(position);
+            MusicPlayerRemote.playSongAt(position, true);
         }
     }
 

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/fragments/player/card/CardPlayerFragment.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/fragments/player/card/CardPlayerFragment.java
@@ -118,7 +118,7 @@ public class CardPlayerFragment extends AbsPlayerFragment implements PlayerAlbum
         });
 
         // for some reason the xml attribute doesn't get applied here.
-        playingQueueCard.setCardBackgroundColor(ATHUtil.resolveColor(getActivity(), R.attr.cardBackgroundColor));
+        playingQueueCard.setCardBackgroundColor(ATHUtil.resolveColor(requireActivity(), R.attr.cardBackgroundColor));
     }
 
     @Override
@@ -178,7 +178,8 @@ public class CardPlayerFragment extends AbsPlayerFragment implements PlayerAlbum
 
     @Override
     public void onMediaStoreChanged() {
-        // TODO If a song is removed from the MediaStore, this is not reflected in the playing queue untill restart
+        // TODO If a song is removed from the MediaStore, this is not reflected in the playing queue until restart
+        // TODO If a song is updated (tags edited), this is not reflected in the playing queue until restart
         updateQueue();
     }
 
@@ -198,7 +199,6 @@ public class CardPlayerFragment extends AbsPlayerFragment implements PlayerAlbum
         }
     }
 
-    @SuppressWarnings("ConstantConditions")
     private void updateCurrentSong() {
         impl.updateCurrentSong(MusicPlayerRemote.getCurrentIndexedSong());
 
@@ -210,20 +210,21 @@ public class CardPlayerFragment extends AbsPlayerFragment implements PlayerAlbum
         playbackControlsFragment = (CardPlayerPlaybackControlsFragment) getChildFragmentManager().findFragmentById(R.id.playback_controls_fragment);
         playerAlbumCoverFragment = (PlayerAlbumCoverFragment) getChildFragmentManager().findFragmentById(R.id.player_album_cover_fragment);
 
+        if (playerAlbumCoverFragment == null) {throw new AssertionError("No fragment with id=" + R.id.player_album_cover_fragment);}
         playerAlbumCoverFragment.setCallbacks(this);
     }
 
     protected void setUpPlayerToolbar() {
         toolbar.inflateMenu(R.menu.menu_player);
         toolbar.setNavigationIcon(R.drawable.ic_close_white_24dp);
-        toolbar.setNavigationOnClickListener(v -> getActivity().onBackPressed());
+        toolbar.setNavigationOnClickListener(v -> requireActivity().onBackPressed());
         toolbar.setOnMenuItemClickListener(this);
 
         super.setUpPlayerToolbar();
     }
 
     @Override
-    public boolean onMenuItemClick(MenuItem item) {
+    public boolean onMenuItemClick(@NonNull MenuItem item) {
         if (item.getItemId() == R.id.action_show_lyrics) {
             if (lyrics != null)
                 LyricsDialog.create(lyrics).show(getParentFragmentManager(), "LYRICS");
@@ -328,7 +329,7 @@ public class CardPlayerFragment extends AbsPlayerFragment implements PlayerAlbum
     protected void toggleFavorite(Song song) {
         super.toggleFavorite(song);
         if (song.id == MusicPlayerRemote.getCurrentSong().id) {
-            if (MusicUtil.isFavorite(getActivity(), song)) {
+            if (MusicUtil.isFavorite(requireActivity(), song)) {
                 playerAlbumCoverFragment.showHeartAnimation();
             }
             updateIsFavorite();
@@ -443,7 +444,7 @@ public class CardPlayerFragment extends AbsPlayerFragment implements PlayerAlbum
 
             animatorSet.play(backgroundAnimator);
 
-            if (!ATHUtil.isWindowBackgroundDark(fragment.getActivity())) {
+            if (!ATHUtil.isWindowBackgroundDark(fragment.requireActivity())) {
                 int adjustedLastColor = ColorUtil.isColorLight(fragment.lastColor) ? ColorUtil.darkenColor(fragment.lastColor) : fragment.lastColor;
                 int adjustedNewColor = ColorUtil.isColorLight(newColor) ? ColorUtil.darkenColor(newColor) : newColor;
                 Animator subHeaderAnimator = ViewUtil.createTextColorTransition(fragment.playerQueueSubHeader, adjustedLastColor, adjustedNewColor);
@@ -460,8 +461,8 @@ public class CardPlayerFragment extends AbsPlayerFragment implements PlayerAlbum
 
         @Override
         public void animateColorChange(int newColor) {
-            if (ATHUtil.isWindowBackgroundDark(fragment.getActivity())) {
-                fragment.playerQueueSubHeader.setTextColor(ThemeStore.textColorSecondary(fragment.getActivity()));
+            if (ATHUtil.isWindowBackgroundDark(fragment.requireActivity())) {
+                fragment.playerQueueSubHeader.setTextColor(ThemeStore.textColorSecondary(fragment.requireActivity()));
             }
         }
     }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/util/MusicUtil.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/util/MusicUtil.java
@@ -293,6 +293,10 @@ public class MusicUtil {
     }
 
     public static Playlist getOrCreateSkippedPlaylist(@NonNull final Context context) {
+        // TODO From time to time, we need to recycle the Skipped songs playlist
+        //      Otherwise add/remove song operation might take long time (seconds) on old playlists.
+        //      There is no measured value for how old this will be a problem though.
+
         return PlaylistLoader.getPlaylist(context, PlaylistsUtil.createPlaylist(context, context.getString(R.string.skipped_songs)));
     }
 
@@ -386,7 +390,7 @@ public class MusicUtil {
                     for (File f : files) {
                         try {
                             String newLyrics = FileUtil.read(f);
-                            if (newLyrics != null && !newLyrics.trim().isEmpty()) {
+                            if (!newLyrics.trim().isEmpty()) {
                                 if (AbsSynchronizedLyrics.isSynchronized(newLyrics)) {
                                     return newLyrics;
                                 }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/util/MusicUtil.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/util/MusicUtil.java
@@ -293,10 +293,6 @@ public class MusicUtil {
     }
 
     public static Playlist getOrCreateSkippedPlaylist(@NonNull final Context context) {
-        // TODO From time to time, we need to recycle the Skipped songs playlist
-        //      Otherwise add/remove song operation might take long time (seconds) on old playlists.
-        //      There is no measured value for how old this will be a problem though.
-
         return PlaylistLoader.getPlaylist(context, PlaylistsUtil.createPlaylist(context, context.getString(R.string.skipped_songs)));
     }
 

--- a/app/src/main/java/com/poupa/vinylmusicplayer/util/PlaylistsUtil.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/util/PlaylistsUtil.java
@@ -38,15 +38,13 @@ public class PlaylistsUtil {
     }
 
     public static boolean doesPlaylistExist(@NonNull final Context context, final long playlistId) {
-        return playlistId != -1 && doesPlaylistExist(context,
-                MediaStore.Audio.Playlists._ID + "=?",
-                new String[]{String.valueOf(playlistId)});
+        return playlistId != -1 && doesPlaylistExistImpl(context,
+                MediaStore.Audio.Playlists._ID + "=" + playlistId);
     }
 
     public static boolean doesPlaylistExist(@NonNull final Context context, final String name) {
-        return doesPlaylistExist(context,
-                MediaStore.Audio.PlaylistsColumns.NAME + "=?",
-                new String[]{name});
+        return doesPlaylistExistImpl(context,
+                MediaStore.Audio.PlaylistsColumns.NAME + "=" + name);
     }
 
     public static long createPlaylist(@NonNull final Context context, @Nullable final String name) {
@@ -253,9 +251,9 @@ public class PlaylistsUtil {
         return M3UWriter.write(context, new File(Environment.getExternalStorageDirectory(), "Playlists"), playlist);
     }
 
-    private static boolean doesPlaylistExist(@NonNull Context context, @NonNull final String selection, @NonNull final String[] values) {
+    private static boolean doesPlaylistExistImpl(@NonNull Context context, @NonNull final String selection) {
         Cursor cursor = context.getContentResolver().query(EXTERNAL_CONTENT_URI,
-                new String[]{}, selection, values, null);
+                new String[]{}, selection, null, null);
 
         boolean exists = false;
         if (cursor != null) {

--- a/app/src/main/java/com/poupa/vinylmusicplayer/util/PlaylistsUtil.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/util/PlaylistsUtil.java
@@ -44,7 +44,7 @@ public class PlaylistsUtil {
 
     public static boolean doesPlaylistExist(@NonNull final Context context, final String name) {
         return doesPlaylistExistImpl(context,
-                MediaStore.Audio.PlaylistsColumns.NAME + "=" + name);
+                MediaStore.Audio.PlaylistsColumns.NAME + "='" + name + "'");
     }
 
     public static long createPlaylist(@NonNull final Context context, @Nullable final String name) {


### PR DESCRIPTION
The "Skipped songs" was updated only if one presses on the Next button.
Now it detects Previous button, UI swipe/fling gestures as well.

Todo
- [x] if song is skipped be selecting another one in queue, the skipped one is not added to the Skipped songs list.