### PR TITLE
Cleaner markdown visualisation

### DIFF
--- a/app/src/main/assets/LICENSES.md
+++ b/app/src/main/assets/LICENSES.md
@@ -3,257 +3,300 @@
 
 
 
-[GNU General Public License v3](https://github.com/VinylMusicPlayer/VinylMusicPlayer/blob/master/LICENSE.txt)
+ - [GNU General Public License v3](https://github.com/VinylMusicPlayer/VinylMusicPlayer/blob/master/LICENSE.txt)
 
+---
 ## Eleven
 
 Copyright The CyanogenMod Project
 
-[Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0)
+ - [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0)
 
+---
 ## StackBlur
 
 Copyright Enrique López Mañas
 
-[Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0)
+ - [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0)
 
+---
 ## The Android Open Source Project
 
 Copyright The Android Open Source Project
 
-[Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0)
+ - [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0)
 
+---
 ## Universal Android Music Player Sample
 
 The goal of this sample is to show how to implement an audio media app that works across multiple form factors and provides a consistent user experience on Android phones, tablets, Android Auto, Android Wear, Android TV, Google Cast devices, and with the Google Assistant.
 
-[Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0)
+ - [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0)
 
+---
 ## com.h6ah4i.android.widget.advrecyclerview.advrecyclerview - Advanced RecyclerView
 
 RecyclerView extension library which provides advanced features. (ex. swiping, drag and drop sorting, expandable items, etc...)
 
-[The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+ - [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+---
 ## androidx.appcompat.appcompat - Android AppCompat Library
 
 The Support Library is a static library that you can add to your Android application in order to use APIs that are either not available for older platform versions or utility APIs that aren't a part of the framework APIs. Compatible on devices running API 14 or later.
 
-[The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+ - [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+---
 ## androidx.constraintlayout.constraintlayout - Android ConstraintLayout
 
 ConstraintLayout for Android
 
-[The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+ - [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+---
 ## androidx.multidex.multidex - Android Multi-Dex Library
 
 Library for legacy multi-dex support
 
-[The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+ - [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+---
 ## androidx.percentlayout.percentlayout - Android Percent Support Library
 
 Android Percent Support Library
 
-[The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+ - [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+---
 ## androidx.preference.preference-ktx - Android Preferences KTX
 
 Kotlin extensions for preferences
 
-[The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+ - [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+---
 ## androidx.gridlayout.gridlayout - Android Support Grid Layout
 
 Android Support Grid Layout
 
-[The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+ - [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+---
 ## androidx.annotation.annotation - Android Support Library Annotations
 
 The Support Library is a static library that you can add to your Android application in order to use APIs that are either not available for older platform versions or utility APIs that aren't a part of the framework APIs.
 
-[The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+ - [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+---
 ## androidx.media.media - Android Support Library media compat
 
 The Support Library is a static library that you can add to your Android application in order to use APIs that are either not available for older platform versions or utility APIs that aren't a part of the framework APIs. Compatible on devices running API 14 or later.
 
-[The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+ - [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+---
 ## androidx.recyclerview.recyclerview - Android Support RecyclerView
 
 Android Support RecyclerView
 
-[The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+ - [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+---
 ## com.github.ksoichiro.android-observablescrollview - Android-ObservableScrollView
 
 Android library to observe scroll events on scrollable views.
 
-[Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0)
+ - [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0)
 
+---
 ## com.squareup.retrofit2.converter-gson - Converter: Gson
 
 Type-safe HTTP client for Android and Java by Square, Inc.
 
-[Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+ - [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
+---
 ## io.noties.markwon.core - Core
 
 Core Markwon artifact that includes basic markdown parsing and rendering
 
-[The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+ - [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+---
 ## androidx.core.core-ktx - Core Kotlin Extensions
 
 Kotlin extensions for 'core' artifact
 
-[The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+ - [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+---
 ## androidx.fragment.fragment-ktx - Fragment Kotlin Extensions
 
 Kotlin extensions for 'fragment' artifact
 
-[The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+ - [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+---
 ## com.github.bumptech.glide.glide - Glide
 
 A fast and efficient image loading library for Android focused on smooth scrolling.
 
-[Simplified BSD License](http://www.opensource.org/licenses/bsd-license)
+ - [Simplified BSD License](http://www.opensource.org/licenses/bsd-license)
 
+---
 ## com.github.bumptech.glide.okhttp3-integration - Glide OkHttp 3.x Integration
 
 An integration library to use OkHttp 3.x to fetch data over http/https in Glide
 
-[Simplified BSD License](http://www.opensource.org/licenses/bsd-license)
+ - [Simplified BSD License](http://www.opensource.org/licenses/bsd-license)
 
+---
 ## com.google.code.gson.gson - Gson
 
 Gson JSON library
 
-[Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+ - [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
+---
 ## io.noties.markwon.image-glide - Image Glide
 
 Markwon image loading module (based on Glide library)
 
-[The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+ - [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+---
 ## org.jetbrains.kotlin.kotlin-stdlib - Kotlin Stdlib
 
 Kotlin Standard Library for JVM
 
-[The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+ - [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+---
 ## io.noties.markwon.linkify - Linkify
 
 Markwon plugin to linkify text (based on Android Linkify)
 
-[The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+ - [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+---
 ## com.google.android.material.material - Material Components for Android
 
 Material Components for Android is a static library that you can add to your Android application in order to use APIs that provide implementations of the Material Design specification. Compatible on devices running API 14 or later.
 
-[The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+ - [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+---
 ## com.afollestad.material-dialogs.commons - Material Dialogs Commons
 
 The commons module for Material Dialogs.
 
-[Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0.txt)
+ - [Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
+---
 ## com.afollestad.material-dialogs.core - Material Dialogs Core
 
 The core module for Material Dialogs.
 
-[Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0.txt)
+ - [Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
+---
 ## com.afollestad.material-cab - Material-cab
 
 🚕 An Android &? Kotlin library for placing and manipulating Contextual Action Bars in your UI.
 
-[Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0.txt)
+ - [Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
+---
 ## me.zhanghai.android.materialprogressbar.library - MaterialProgressBar Library
 
 A Material Design ProgressBar with consistent appearance
 
-[The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+ - [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+---
 ## androidx.palette.palette-ktx - Palette Kotlin Extensions
 
 Kotlin extensions for 'palette' artifact
 
-[The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+ - [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+---
 ## com.squareup.retrofit2.retrofit - Retrofit
 
 Type-safe HTTP client for Android and Java by Square, Inc.
 
-[Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+ - [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
+---
 ## androidx.databinding.databinding-common - androidx.databinding.databinding-common
 
 Shared library between Data Binding runtime lib and compiler
 
-[The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+ - [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+---
 ## androidx.databinding.databinding-adapters
 
 
 
-[The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+ - [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+---
 ## androidx.databinding.databinding-ktx
 
 
 
-[The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+ - [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+---
 ## androidx.databinding.databinding-runtime
 
 
 
-[The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+ - [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+---
 ## androidx.databinding.viewbinding
 
 
 
-[The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+ - [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+---
 ## RecyclerView-FastScroll
 
 A simple FastScroller for Android's RecyclerView. Copyright (C) 2016 Tim Malseed
 
-[The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)
+ - [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)
 
+---
 ## SeekArc
 
 Copyright (c) 2013 Triggertrap Ltd, Author Neil Davies
 
-[MIT License](https://api.github.com/licenses/mit)
+ - [MIT License](https://api.github.com/licenses/mit)
 
+---
 ## com.heinrichreimersoftware.material-intro - heinrichreimer/material-intro
 
 A simple material design app intro with cool animations and a fluent API.
 
-[MIT License](https://api.github.com/licenses/mit)
+ - [MIT License](https://api.github.com/licenses/mit)
 
+---
 ## net.jthink.jaudiotagger - jaudiotagger
 
 The aim of this project is to provide a world class Java library       for editing tag information in audio files.       Most existing solutions are not java based inhibiting the use of       java applications with digital files.
 
-[LGPL](http://www.gnu.org/copyleft/lesser.html)
+ - [LGPL](http://www.gnu.org/copyleft/lesser.html)
 
+---
 ## com.github.kabouzeid.AndroidSlidingUpPanel - kabouzeid/AndroidSlidingUpPanel
 
 This library provides a simple way to add a draggable sliding up panel (popularized by Google Music and Google Maps) to your Android application. Brought to you by Umano.
 
-[Apache License 2.0](https://api.github.com/licenses/apache-2.0)
+ - [Apache License 2.0](https://api.github.com/licenses/apache-2.0)
 
+---

--- a/app/src/main/java/com/poupa/vinylmusicplayer/dialogs/MarkdownViewDialog.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/dialogs/MarkdownViewDialog.java
@@ -3,7 +3,10 @@ package com.poupa.vinylmusicplayer.dialogs;
 import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.app.Dialog;
+import android.graphics.Color;
+import android.graphics.Typeface;
 import android.os.Bundle;
+import android.util.TypedValue;
 import android.view.View;
 import android.widget.TextView;
 
@@ -22,6 +25,7 @@ import java.nio.charset.StandardCharsets;
 
 import io.noties.markwon.AbstractMarkwonPlugin;
 import io.noties.markwon.Markwon;
+import io.noties.markwon.core.MarkwonTheme;
 import io.noties.markwon.image.glide.GlideImagesPlugin;
 
 /**
@@ -48,9 +52,24 @@ public class MarkdownViewDialog extends DialogFragment {
                 .positiveText(android.R.string.ok)
                 .build();
 
+        final TypedValue typedColor = new TypedValue();
+        getActivity().getTheme().resolveAttribute(R.attr.dividerColor, typedColor, true);
+
         final Markwon markwon = Markwon.builder(activity)
                 .usePlugin(GlideImagesPlugin.create(activity)) // image loader
                 .usePlugin(new GithubLinkify())
+                .usePlugin(new AbstractMarkwonPlugin() {
+                    @Override
+                    public void configureTheme(@NonNull MarkwonTheme.Builder builder) {
+                        builder
+                                .headingBreakColor(Color.parseColor("#00ffffff"))
+                                .thematicBreakColor(typedColor.data)
+                                .thematicBreakHeight(2)
+                                .bulletWidth(12)
+                                .headingTextSizeMultipliers(
+                                        new float[] { 2.F, 1.5F, 1F, .83F, .67F, .55F });
+                    }
+                })
                 .build();
         final TextView markdownView = customView.findViewById(R.id.markdown_view);
         StringBuilder buf = loadFileFromAssets(activity, assetName);

--- a/app/src/main/res/layout/dialog_markdown_view.xml
+++ b/app/src/main/res/layout/dialog_markdown_view.xml
@@ -1,16 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:paddingLeft="16dp"
-    android:paddingRight="16dp">
+    android:layout_height="match_parent">
 
     <TextView
         android:id="@+id/markdown_view"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/default_item_margin"
-        android:textIsSelectable="false"
-        android:scrollbars="vertical" />
+        android:textIsSelectable="true"
+        android:layout_margin="@dimen/default_item_margin"
+        android:scrollbars="vertical"
+        android:textAppearance="@style/TextAppearance.AppCompat.Subhead" />
 
-</FrameLayout>
+
+</ScrollView>

--- a/app/src/main/res/layout/dialog_markdown_view.xml
+++ b/app/src/main/res/layout/dialog_markdown_view.xml
@@ -8,7 +8,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/default_item_margin"
-        android:textIsSelectable="true"
+        android:textIsSelectable="false"
         android:layout_margin="@dimen/default_item_margin"
         android:scrollbars="vertical"
         android:textAppearance="@style/TextAppearance.AppCompat.Subhead" />

--- a/script/build-licenses-page
+++ b/script/build-licenses-page
@@ -125,8 +125,9 @@ licenses_md="app/src/main/assets/LICENSES.md"
 
 ${dep_desc}
 
-[${dep_license}](${dep_license_url})
+ - [${dep_license}](${dep_license_url})
 
+---
 ITEM
   done
 } > ${licenses_md}


### PR DESCRIPTION
I am a fan of the scripted .md file but the user experiences is a little bit glaring in my opinion.

I this PR I am adding inertial scrolling, removing all the header line but keeping some for licenses:
![licenses](https://user-images.githubusercontent.com/56130419/217378273-f70ad95b-b1e8-4e63-bce6-56235d851519.png)
![changelog](https://user-images.githubusercontent.com/56130419/217378288-c7909ad5-ff8d-4e76-895c-06ea1c5a4cf0.png)
