### PR TITLE
Enqueue song action can now be choosen in preference

### DIFF
--- a/app/src/main/java/com/poupa/vinylmusicplayer/dialogs/BottomSheetDialog/BottomSheetDialogWithButtons.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/dialogs/BottomSheetDialog/BottomSheetDialogWithButtons.java
@@ -16,7 +16,9 @@ import android.widget.Button;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
+import androidx.annotation.DrawableRes;
 import androidx.annotation.Nullable;
+import androidx.annotation.StringRes;
 import androidx.core.content.ContextCompat;
 import androidx.core.graphics.drawable.DrawableCompat;
 import com.kabouzeid.appthemehelper.ThemeStore;
@@ -120,7 +122,9 @@ public class BottomSheetDialogWithButtons extends BottomSheetDialog {
 
     public static class ButtonInfo {
         public int id;
+        @StringRes
         public int titleId;
+        @DrawableRes
         public Integer iconId;
         public Runnable action;
 

--- a/app/src/main/java/com/poupa/vinylmusicplayer/dialogs/BottomSheetDialog/BottomSheetDialogWithButtons.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/dialogs/BottomSheetDialog/BottomSheetDialogWithButtons.java
@@ -3,6 +3,7 @@ package com.poupa.vinylmusicplayer.dialogs.BottomSheetDialog;
 
 import java.util.List;
 
+import android.content.Context;
 import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
@@ -16,6 +17,7 @@ import android.widget.LinearLayout;
 import android.widget.TextView;
 
 import androidx.annotation.Nullable;
+import androidx.core.content.ContextCompat;
 import androidx.core.graphics.drawable.DrawableCompat;
 import com.kabouzeid.appthemehelper.ThemeStore;
 import com.poupa.vinylmusicplayer.R;
@@ -26,6 +28,7 @@ public class BottomSheetDialogWithButtons extends BottomSheetDialog {
 
     String title;
     List<ButtonInfo> buttonList;
+    int defaultIndex = -1;
 
     public BottomSheetDialogWithButtons setTitle(String title) {
         this.title = title;
@@ -36,10 +39,18 @@ public class BottomSheetDialogWithButtons extends BottomSheetDialog {
         return this;
     }
 
+    public BottomSheetDialogWithButtons setDefaultButtonIndex(int defaultIndex) {
+        this.defaultIndex = defaultIndex;
+        return this;
+    }
+
     @Nullable
     @Override
     public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.bottom_sheet_button_list, container, false);
+        Context context = getContext();
+
+        if (buttonList == null || context == null) { dismiss(); return view; }
 
         TextView titleView = view.findViewById(R.id.title);
         titleView.setText(title);
@@ -47,7 +58,7 @@ public class BottomSheetDialogWithButtons extends BottomSheetDialog {
         for (int i = 0; i < buttonList.size(); i++) {
             final Button button;
 
-            button = new Button(view.getContext(), null);
+            button = new Button(context, null);
 
             button.setTag(i);
             button.setOnClickListener(new View.OnClickListener() {
@@ -60,10 +71,10 @@ public class BottomSheetDialogWithButtons extends BottomSheetDialog {
             });
 
             TypedValue outValue = new TypedValue();
-            getContext().getTheme().resolveAttribute(R.attr.selectableItemBackground, outValue, true);
+            context.getTheme().resolveAttribute(R.attr.selectableItemBackground, outValue, true);
             button.setBackgroundResource(outValue.resourceId);
-            int px_vertical = getContext().getResources().getDimensionPixelSize(R.dimen.bottom_sheet_vertical_divided_margin);
-            int px_horizontal = getContext().getResources().getDimensionPixelSize(R.dimen.default_item_margin);
+            int px_vertical = context.getResources().getDimensionPixelSize(R.dimen.bottom_sheet_vertical_divided_margin);
+            int px_horizontal = context.getResources().getDimensionPixelSize(R.dimen.default_item_margin);
             button.setPadding(px_horizontal, px_vertical, px_horizontal, px_vertical);
 
             LinearLayout linearlayout = (LinearLayout) view.findViewById(R.id.buttonList);
@@ -75,16 +86,25 @@ public class BottomSheetDialogWithButtons extends BottomSheetDialog {
             buttonParams.setMargins(0, 0, 0, 0);
 
             int colorPrimary = ThemeStore.textColorPrimary(getActivity());
+            int accentColor = ThemeStore.accentColor(getActivity());
             button.setGravity(Gravity.START|Gravity.CENTER_VERTICAL);
             button.setTypeface(null, Typeface.NORMAL);
             button.setTransformationMethod(null);
-            button.setTextColor(colorPrimary);
-            button.setText(buttonList.get(i).title);
+            if (i == defaultIndex) {
+                button.setTextColor(accentColor);
+            } else {
+                button.setTextColor(colorPrimary);
+            }
+            button.setText(context.getString(buttonList.get(i).titleId));
             button.setTextSize(TypedValue.COMPLEX_UNIT_SP,16);
 
-            Drawable icon = buttonList.get(i).icon;
-            if (icon != null) {
-                DrawableCompat.setTint(icon, colorPrimary);
+            if (buttonList.get(i).iconId != null) {
+                Drawable icon = ContextCompat.getDrawable(context, buttonList.get(i).iconId);
+                if (i == defaultIndex) {
+                    DrawableCompat.setTint(icon, accentColor);
+                } else {
+                    DrawableCompat.setTint(icon, colorPrimary);
+                }
                 button.setCompoundDrawablesWithIntrinsicBounds(icon, null, null, null);
                 button.setCompoundDrawablePadding((int)(1.5*px_horizontal));
             }
@@ -99,20 +119,28 @@ public class BottomSheetDialogWithButtons extends BottomSheetDialog {
     }
 
     public static class ButtonInfo {
-        public String title;
+        public int id;
+        public int titleId;
+        public Integer iconId;
         public Runnable action;
-        public Drawable icon;
 
-        public ButtonInfo(String title, Runnable action) {
-            this.title = title;
+        public ButtonInfo(int id, int titleId, Runnable action) {
+            this.id = id;
+            this.titleId = titleId;
             this.action = action;
-            this.icon = null;
+            this.iconId = null;
         }
 
-        public ButtonInfo(String title, Runnable action, Drawable icon) {
-            this.title = title;
+        public ButtonInfo(int id, int titleId, int iconId, Runnable action) {
+            this.id = id;
+            this.titleId = titleId;
             this.action = action;
-            this.icon = icon;
+            this.iconId = iconId;
+        }
+
+        public ButtonInfo setAction(Runnable action) {
+            this.action = action;
+            return this;
         }
     }
 

--- a/app/src/main/java/com/poupa/vinylmusicplayer/preferences/SongConfirmationPreference.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/preferences/SongConfirmationPreference.java
@@ -1,0 +1,40 @@
+package com.poupa.vinylmusicplayer.preferences;
+
+
+import java.util.Arrays;
+import java.util.List;
+
+import android.content.Context;
+import android.util.AttributeSet;
+
+import com.kabouzeid.appthemehelper.common.prefs.supportv7.ATEDialogPreference;
+import com.poupa.vinylmusicplayer.R;
+import com.poupa.vinylmusicplayer.dialogs.BottomSheetDialog.BottomSheetDialogWithButtons;
+import com.poupa.vinylmusicplayer.dialogs.BottomSheetDialog.BottomSheetDialogWithButtons.ButtonInfo;
+import com.poupa.vinylmusicplayer.util.PreferenceUtil;
+
+
+public class SongConfirmationPreference extends ATEDialogPreference {
+   public static BottomSheetDialogWithButtons.ButtonInfo ASK = new ButtonInfo(PreferenceUtil.ENQUEUE_SONGS_CHOICE_ASK, R.string.action_always_ask_for_confirmation, R.drawable.ic_close_white_24dp, null);
+   public static BottomSheetDialogWithButtons.ButtonInfo REPLACE = new ButtonInfo(PreferenceUtil.ENQUEUE_SONGS_CHOICE_REPLACE, R.string.action_play, R.drawable.ic_play_arrow_white_24dp, null);
+   public static BottomSheetDialogWithButtons.ButtonInfo NEXT = new ButtonInfo(PreferenceUtil.ENQUEUE_SONGS_CHOICE_NEXT, R.string.action_play_next, R.drawable.ic_redo_white_24dp, null);
+   public static BottomSheetDialogWithButtons.ButtonInfo ADD = new ButtonInfo(PreferenceUtil.ENQUEUE_SONGS_CHOICE_ADD, R.string.action_add_to_playing_queue, R.drawable.ic_library_add_white_24dp, null);
+
+   public static final List<ButtonInfo> possibleActions = Arrays.asList(ASK, REPLACE, NEXT, ADD);
+
+   public SongConfirmationPreference(Context context) {
+      super(context);
+   }
+
+   public SongConfirmationPreference(Context context, AttributeSet attrs) {
+      super(context, attrs);
+   }
+
+   public SongConfirmationPreference(Context context, AttributeSet attrs, int defStyleAttr) {
+      super(context, attrs, defStyleAttr);
+   }
+
+   public SongConfirmationPreference(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
+      super(context, attrs, defStyleAttr, defStyleRes);
+   }
+}

--- a/app/src/main/java/com/poupa/vinylmusicplayer/preferences/SongConfirmationPreference.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/preferences/SongConfirmationPreference.java
@@ -15,7 +15,7 @@ import com.poupa.vinylmusicplayer.util.PreferenceUtil;
 
 
 public class SongConfirmationPreference extends ATEDialogPreference {
-   public static BottomSheetDialogWithButtons.ButtonInfo ASK = new ButtonInfo(PreferenceUtil.ENQUEUE_SONGS_CHOICE_ASK, R.string.action_always_ask_for_confirmation, R.drawable.ic_close_white_24dp, null);
+   public static BottomSheetDialogWithButtons.ButtonInfo ASK = new ButtonInfo(PreferenceUtil.ENQUEUE_SONGS_CHOICE_ASK, R.string.action_always_ask_for_confirmation, R.drawable.ic_playlist_play_white_24dp, null);
    public static BottomSheetDialogWithButtons.ButtonInfo REPLACE = new ButtonInfo(PreferenceUtil.ENQUEUE_SONGS_CHOICE_REPLACE, R.string.action_play, R.drawable.ic_play_arrow_white_24dp, null);
    public static BottomSheetDialogWithButtons.ButtonInfo NEXT = new ButtonInfo(PreferenceUtil.ENQUEUE_SONGS_CHOICE_NEXT, R.string.action_play_next, R.drawable.ic_redo_white_24dp, null);
    public static BottomSheetDialogWithButtons.ButtonInfo ADD = new ButtonInfo(PreferenceUtil.ENQUEUE_SONGS_CHOICE_ADD, R.string.action_add_to_playing_queue, R.drawable.ic_library_add_white_24dp, null);

--- a/app/src/main/java/com/poupa/vinylmusicplayer/util/PreferenceUtil.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/util/PreferenceUtil.java
@@ -134,6 +134,12 @@ public final class PreferenceUtil {
     public static final byte RG_SOURCE_MODE_ALBUM = 2;
 
     private static final String SAF_SDCARD_URI = "saf_sdcard_uri";
+    public static final String ENQUEUE_SONGS_DEFAULT_CHOICE = "enqueue_songs_default_choice";
+
+    public static final int ENQUEUE_SONGS_CHOICE_ASK = 0;
+    public static final int ENQUEUE_SONGS_CHOICE_REPLACE = 1;
+    public static final int ENQUEUE_SONGS_CHOICE_NEXT = 2;
+    public static final int ENQUEUE_SONGS_CHOICE_ADD = 3;
 
     private static PreferenceUtil sInstance;
 
@@ -758,6 +764,16 @@ public final class PreferenceUtil {
     public void setSAFSDCardUri(@NonNull final Uri uri) {
         mPreferences.edit()
                 .putString(SAF_SDCARD_URI, uri.toString())
+                .apply();
+    }
+
+    public int getEnqueueSongsDefaultChoice() {
+        return mPreferences.getInt(ENQUEUE_SONGS_DEFAULT_CHOICE, ENQUEUE_SONGS_CHOICE_REPLACE);
+    }
+
+    public void setEnqueueSongsDefaultChoice(int choice) {
+        mPreferences.edit()
+                .putInt(ENQUEUE_SONGS_DEFAULT_CHOICE, choice)
                 .apply();
     }
 }

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -33,6 +33,8 @@
     <string name="action_add_to_playing_queue">Ajouter à la file de lecture</string>
     <string name="action_remove_from_playing_queue">Retirer de la file de lecture</string>
     <string name="action_add_to_playlist">Ajouter à une playlist</string>
+    <string name="pref_title_enqueue_song_default_choice">Action après un appuis sur un titre</string>
+    <string name="action_always_ask_for_confirmation">Toujours demander la confirmation de l\'action</string>
     <string name="action_tag_editor">Éditeur d\'informations</string>
     <string name="action_delete_from_device">Supprimer de l\'appareil</string>
     <string name="action_details">Détails</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -33,7 +33,7 @@
     <string name="action_add_to_playing_queue">Ajouter à la file de lecture</string>
     <string name="action_remove_from_playing_queue">Retirer de la file de lecture</string>
     <string name="action_add_to_playlist">Ajouter à une playlist</string>
-    <string name="pref_title_enqueue_song_default_choice">Action après un appuis sur un titre</string>
+    <string name="pref_title_enqueue_song_default_choice">Action par default après un appuis sur un titre</string>
     <string name="action_always_ask_for_confirmation">Toujours demander la confirmation de l\'action</string>
     <string name="action_tag_editor">Éditeur d\'informations</string>
     <string name="action_delete_from_device">Supprimer de l\'appareil</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -20,6 +20,8 @@
     <string name="action_previous">Previous</string>
     <string name="action_next">Next</string>
 
+    <string name="pref_title_enqueue_song_default_choice">Enqueue song default action</string>
+    <string name="action_always_ask_for_confirmation">Always ask for actions</string>
     <string name="action_add_to_playing_queue">Add to playing queue</string>
     <string name="action_remove_from_playing_queue">Remove from playing queue</string>
     <string name="action_clear_playing_queue">Clear playing queue</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -20,7 +20,7 @@
     <string name="action_previous">Previous</string>
     <string name="action_next">Next</string>
 
-    <string name="pref_title_enqueue_song_default_choice">Enqueue song default action</string>
+    <string name="pref_title_enqueue_song_default_choice">Default action on choosing/tapping a song while browsing</string>
     <string name="action_always_ask_for_confirmation">Always ask for actions</string>
     <string name="action_add_to_playing_queue">Add to playing queue</string>
     <string name="action_remove_from_playing_queue">Remove from playing queue</string>

--- a/app/src/main/res/xml/pref_now_playing_screen.xml
+++ b/app/src/main/res/xml/pref_now_playing_screen.xml
@@ -30,6 +30,12 @@
             android:summary="@string/pref_summary_show_song_number"
             android:title="@string/pref_title_show_song_number" />
 
+        <com.poupa.vinylmusicplayer.preferences.SongConfirmationPreference
+            app:iconSpaceReserved="false"
+            android:key="enqueue_songs_default_choice"
+            android:title="@string/pref_title_enqueue_song_default_choice"
+            />
+
     </com.kabouzeid.appthemehelper.common.prefs.supportv7.ATEPreferenceCategory>
 
 </androidx.preference.PreferenceScreen>


### PR DESCRIPTION
To resolve user feedback in: https://github.com/VinylMusicPlayer/VinylMusicPlayer/pull/658  
And new request https://github.com/VinylMusicPlayer/VinylMusicPlayer/issues/708  

This add a preference to choose between confirmation dialog or some default action:
![Screenshot_20230304-222818](https://user-images.githubusercontent.com/56130419/222929451-34ea2d15-cb26-424f-8619-e152bbeea185.png)

By default it is set to replace queue like in 1.4
