### PR TITLE
Cab icon tint

### DIFF
--- a/app/src/main/java/com/poupa/vinylmusicplayer/dialogs/BottomSheetDialog/BottomSheetDialog.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/dialogs/BottomSheetDialog/BottomSheetDialog.java
@@ -7,10 +7,9 @@ import android.view.View;
 import android.widget.FrameLayout;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
+
 import com.google.android.material.bottomsheet.BottomSheetBehavior;
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment;
-import com.poupa.vinylmusicplayer.R;
 import com.poupa.vinylmusicplayer.util.ImageTheme.ThemeStyleUtil;
 
 
@@ -21,7 +20,7 @@ public abstract class BottomSheetDialog extends BottomSheetDialogFragment {
     public Dialog onCreateDialog(Bundle savedInstanceState) {
 
         com.google.android.material.bottomsheet.BottomSheetDialog
-                dialog = new com.google.android.material.bottomsheet.BottomSheetDialog(getActivity(), ThemeStyleUtil.getInstance().getBottomSheetStyle());
+                dialog = new com.google.android.material.bottomsheet.BottomSheetDialog(requireActivity(), ThemeStyleUtil.getInstance().getBottomSheetStyle());
 
         dialog.setOnShowListener(new DialogInterface.OnShowListener() {
             @Override

--- a/app/src/main/java/com/poupa/vinylmusicplayer/dialogs/BottomSheetDialog/BottomSheetDialogWithButtons.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/dialogs/BottomSheetDialog/BottomSheetDialogWithButtons.java
@@ -1,5 +1,8 @@
 package com.poupa.vinylmusicplayer.dialogs.BottomSheetDialog;
 
+
+import java.util.List;
+
 import android.content.Context;
 import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
@@ -18,11 +21,9 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
 import androidx.core.content.ContextCompat;
-
+import androidx.core.graphics.drawable.DrawableCompat;
 import com.kabouzeid.appthemehelper.ThemeStore;
 import com.poupa.vinylmusicplayer.R;
-
-import java.util.List;
 
 public class BottomSheetDialogWithButtons extends BottomSheetDialog {
     public static BottomSheetDialogWithButtons newInstance() { return new BottomSheetDialogWithButtons(); }
@@ -99,13 +100,11 @@ public class BottomSheetDialogWithButtons extends BottomSheetDialog {
 
             if (buttonList.get(i).iconId != null) {
                 Drawable icon = ContextCompat.getDrawable(context, buttonList.get(i).iconId);
-                // TODO Decorate the default item (ex: bold text)
-                //if (i == defaultIndex) {
-                //    DrawableCompat.setTint(icon, accentColor);
-                //    button.getText(context.getString(buttonList.get(i).titleId));
-                //} else {
-                //    DrawableCompat.setTint(icon, colorPrimary);
-                //}
+                if (i == defaultIndex) {
+                    DrawableCompat.setTint(icon, accentColor);
+                } else {
+                    DrawableCompat.setTint(icon, colorPrimary);
+                }
                 button.setCompoundDrawablesWithIntrinsicBounds(icon, null, null, null);
                 button.setCompoundDrawablePadding((int)(1.5*px_horizontal));
             }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/dialogs/BottomSheetDialog/BottomSheetDialogWithButtons.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/dialogs/BottomSheetDialog/BottomSheetDialogWithButtons.java
@@ -1,8 +1,6 @@
 package com.poupa.vinylmusicplayer.dialogs.BottomSheetDialog;
 
 
-import java.util.List;
-
 import android.content.Context;
 import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
@@ -22,8 +20,11 @@ import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
 import androidx.core.content.ContextCompat;
 import androidx.core.graphics.drawable.DrawableCompat;
+
 import com.kabouzeid.appthemehelper.ThemeStore;
 import com.poupa.vinylmusicplayer.R;
+
+import java.util.List;
 
 public class BottomSheetDialogWithButtons extends BottomSheetDialog {
     public static BottomSheetDialogWithButtons newInstance() { return new BottomSheetDialogWithButtons(); }
@@ -85,8 +86,8 @@ public class BottomSheetDialogWithButtons extends BottomSheetDialog {
                     LinearLayout.LayoutParams.WRAP_CONTENT);
             buttonParams.setMargins(0, 0, 0, 0);
 
-            int colorPrimary = ThemeStore.textColorPrimary(getActivity());
-            int accentColor = ThemeStore.accentColor(getActivity());
+            int colorPrimary = ThemeStore.textColorPrimary(requireActivity());
+            int accentColor = ThemeStore.accentColor(requireActivity());
             button.setGravity(Gravity.START|Gravity.CENTER_VERTICAL);
             button.setTypeface(null, Typeface.NORMAL);
             button.setTransformationMethod(null);
@@ -100,6 +101,7 @@ public class BottomSheetDialogWithButtons extends BottomSheetDialog {
 
             if (buttonList.get(i).iconId != null) {
                 Drawable icon = ContextCompat.getDrawable(context, buttonList.get(i).iconId);
+                icon.mutate(); // make own copy, so that the tint effect wont contaminate other (shared) use of this same icon
                 if (i == defaultIndex) {
                     DrawableCompat.setTint(icon, accentColor);
                 } else {

--- a/app/src/main/java/com/poupa/vinylmusicplayer/dialogs/BottomSheetDialog/BottomSheetDialogWithButtons.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/dialogs/BottomSheetDialog/BottomSheetDialogWithButtons.java
@@ -1,8 +1,5 @@
 package com.poupa.vinylmusicplayer.dialogs.BottomSheetDialog;
 
-
-import java.util.List;
-
 import android.content.Context;
 import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
@@ -17,12 +14,15 @@ import android.widget.LinearLayout;
 import android.widget.TextView;
 
 import androidx.annotation.DrawableRes;
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
 import androidx.core.content.ContextCompat;
-import androidx.core.graphics.drawable.DrawableCompat;
+
 import com.kabouzeid.appthemehelper.ThemeStore;
 import com.poupa.vinylmusicplayer.R;
+
+import java.util.List;
 
 
 public class BottomSheetDialogWithButtons extends BottomSheetDialog {
@@ -102,11 +102,13 @@ public class BottomSheetDialogWithButtons extends BottomSheetDialog {
 
             if (buttonList.get(i).iconId != null) {
                 Drawable icon = ContextCompat.getDrawable(context, buttonList.get(i).iconId);
-                if (i == defaultIndex) {
-                    DrawableCompat.setTint(icon, accentColor);
-                } else {
-                    DrawableCompat.setTint(icon, colorPrimary);
-                }
+                // TODO Decorate the default item (ex: bold text)
+                //if (i == defaultIndex) {
+                //    DrawableCompat.setTint(icon, accentColor);
+                //    button.getText(context.getString(buttonList.get(i).titleId));
+                //} else {
+                //    DrawableCompat.setTint(icon, colorPrimary);
+                //}
                 button.setCompoundDrawablesWithIntrinsicBounds(icon, null, null, null);
                 button.setCompoundDrawablePadding((int)(1.5*px_horizontal));
             }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/dialogs/BottomSheetDialog/BottomSheetDialogWithButtons.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/dialogs/BottomSheetDialog/BottomSheetDialogWithButtons.java
@@ -24,7 +24,6 @@ import com.poupa.vinylmusicplayer.R;
 
 import java.util.List;
 
-
 public class BottomSheetDialogWithButtons extends BottomSheetDialog {
     public static BottomSheetDialogWithButtons newInstance() { return new BottomSheetDialogWithButtons(); }
 
@@ -36,6 +35,7 @@ public class BottomSheetDialogWithButtons extends BottomSheetDialog {
         this.title = title;
         return this;
     }
+
     public BottomSheetDialogWithButtons setButtonList(List<ButtonInfo> buttonList) {
         this.buttonList = buttonList;
         return this;
@@ -48,7 +48,7 @@ public class BottomSheetDialogWithButtons extends BottomSheetDialog {
 
     @Nullable
     @Override
-    public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.bottom_sheet_button_list, container, false);
         Context context = getContext();
 
@@ -63,13 +63,10 @@ public class BottomSheetDialogWithButtons extends BottomSheetDialog {
             button = new Button(context, null);
 
             button.setTag(i);
-            button.setOnClickListener(new View.OnClickListener() {
-                @Override
-                public void onClick(View v) {
-                    int i = (Integer)v.getTag();
-                    buttonList.get(i).action.run();
-                    afterClickOn(i);
-                }
+            button.setOnClickListener(v -> {
+                int i1 = (Integer)v.getTag();
+                buttonList.get(i1).action.run();
+                afterClickOn(i1);
             });
 
             TypedValue outValue = new TypedValue();
@@ -79,7 +76,7 @@ public class BottomSheetDialogWithButtons extends BottomSheetDialog {
             int px_horizontal = context.getResources().getDimensionPixelSize(R.dimen.default_item_margin);
             button.setPadding(px_horizontal, px_vertical, px_horizontal, px_vertical);
 
-            LinearLayout linearlayout = (LinearLayout) view.findViewById(R.id.buttonList);
+            LinearLayout linearlayout = view.findViewById(R.id.buttonList);
             linearlayout.setOrientation(LinearLayout.VERTICAL);
 
             LinearLayout.LayoutParams buttonParams = new LinearLayout.LayoutParams(
@@ -129,13 +126,6 @@ public class BottomSheetDialogWithButtons extends BottomSheetDialog {
         @DrawableRes
         public Integer iconId;
         public Runnable action;
-
-        public ButtonInfo(int id, int titleId, Runnable action) {
-            this.id = id;
-            this.titleId = titleId;
-            this.action = action;
-            this.iconId = null;
-        }
 
         public ButtonInfo(int id, int titleId, int iconId, Runnable action) {
             this.id = id;


### PR DESCRIPTION
Circumvent the CAB/Toolbar bad icon color - the curved arrow in the screenshot below

![Screenshot_20230317-224909_Vinyl Music Player](https://user-images.githubusercontent.com/13333482/226060011-5e164f5c-f78c-4741-bfc9-d5f7ded31cb8.jpg)

Related references:
- https://stackoverflow.com/questions/28219178/toolbar-icon-tinting-on-android
- https://stackoverflow.com/questions/26780046/menuitem-tinting-on-appcompat-toolbar
- https://issuetracker.google.com/issues/37127128
