### PR TITLE
Dont crash if OopsHandler is called from a background (non-UI) thread

### DIFF
--- a/app/src/main/java/com/poupa/vinylmusicplayer/adapter/PlaylistAdapter.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/adapter/PlaylistAdapter.java
@@ -195,7 +195,7 @@ public class PlaylistAdapter extends AbsMultiSelectAdapter<PlaylistAdapter.ViewH
                     dir = PlaylistsUtil.savePlaylist(context, playlist);
                     successes++;
                 } catch (IOException e) {
-                    OopsHandler.copyStackTraceToClipboard(context, e);
+                    OopsHandler.copyStackTraceToClipboard(e);
                     failures++;
                 }
             }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/dialogs/helper/DeleteSongsDialogAndroidR.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/dialogs/helper/DeleteSongsDialogAndroidR.java
@@ -160,7 +160,7 @@ public class DeleteSongsDialogAndroidR extends Fragment {
                     }
                 }
             } catch (Exception e) {
-                OopsHandler.copyStackTraceToClipboard(activity, e);
+                OopsHandler.copyStackTraceToClipboard(e);
             }
 
             return null;

--- a/app/src/main/java/com/poupa/vinylmusicplayer/discog/tagging/TagExtractor.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/discog/tagging/TagExtractor.java
@@ -88,7 +88,7 @@ public class TagExtractor {
             song.replayGainAlbum = rgValues.album;
             song.replayGainTrack = rgValues.track;
         } catch (@NonNull Exception | NoSuchMethodError | VerifyError e) {
-            OopsHandler.copyStackTraceToClipboard(App.getStaticContext(), e);
+            OopsHandler.copyStackTraceToClipboard(e);
         }
     }
 }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/helper/menu/PlaylistMenuHelper.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/helper/menu/PlaylistMenuHelper.java
@@ -66,7 +66,7 @@ public class PlaylistMenuHelper {
                 final String file = PlaylistsUtil.savePlaylist(context, playlist);
                 return context.getString(R.string.saved_playlist_to, file);
             } catch (IOException e) {
-                OopsHandler.copyStackTraceToClipboard(context, e);
+                OopsHandler.copyStackTraceToClipboard(e);
                 return context.getString(R.string.failed_to_save_playlist, e);
             }
         }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/tageditor/AbsTagEditorActivity.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/tageditor/AbsTagEditorActivity.java
@@ -431,7 +431,7 @@ public abstract class AbsTagEditorActivity extends AbsBaseActivity {
                         info.artworkInfo.artwork.compress(Bitmap.CompressFormat.PNG, 0, new FileOutputStream(albumArtFile.get().getCanonicalFile()));
                         artwork = ArtworkFactory.createArtworkFromFile(albumArtFile.get());
                     } catch (IOException e) {
-                        OopsHandler.copyStackTraceToClipboard(activity.get(), e);
+                        OopsHandler.copyStackTraceToClipboard(e);
                     }
                 }
 
@@ -458,7 +458,7 @@ public abstract class AbsTagEditorActivity extends AbsBaseActivity {
                                         tag.setField(entry.getKey(), entry.getValue().trim());
                                     }
                                 } catch (Exception e) {
-                                    OopsHandler.copyStackTraceToClipboard(activity.get(), e);
+                                    OopsHandler.copyStackTraceToClipboard(e);
                                 }
                             }
                         }
@@ -474,7 +474,7 @@ public abstract class AbsTagEditorActivity extends AbsBaseActivity {
 
                         SAFUtil.write(activity.get(), audioFile, song);
                     } catch (@NonNull Exception | NoSuchMethodError | VerifyError e) {
-                        OopsHandler.copyStackTraceToClipboard(activity.get(), e);
+                        OopsHandler.copyStackTraceToClipboard(e);
                     }
                 }
 
@@ -485,7 +485,7 @@ public abstract class AbsTagEditorActivity extends AbsBaseActivity {
 
                 return paths.toArray(new String[0]);
             } catch (Exception e) {
-                OopsHandler.copyStackTraceToClipboard(activity.get(), e);
+                OopsHandler.copyStackTraceToClipboard(e);
                 return null;
             }
         }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/tageditor/AlbumTagEditorActivity.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/tageditor/AlbumTagEditorActivity.java
@@ -91,7 +91,7 @@ public class AlbumTagEditorActivity extends AbsTagEditorActivity implements Text
                 year.setText(getSongYear(audio.get()));
             }
         } catch (Exception e) {
-            OopsHandler.copyStackTraceToClipboard(this, e);
+            OopsHandler.copyStackTraceToClipboard(e);
         }
     }
 
@@ -102,7 +102,7 @@ public class AlbumTagEditorActivity extends AbsTagEditorActivity implements Text
             setImageBitmap(bitmap, VinylMusicPlayerColorUtil.getColor(VinylMusicPlayerColorUtil.generatePalette(bitmap), ATHUtil.resolveColor(this, R.attr.defaultFooterColor)));
             deleteAlbumArt = false;
         } catch (Exception e) {
-            OopsHandler.copyStackTraceToClipboard(this, e);
+            OopsHandler.copyStackTraceToClipboard(e);
         }
     }
 

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/tageditor/SongTagEditorActivity.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/tageditor/SongTagEditorActivity.java
@@ -78,7 +78,7 @@ public class SongTagEditorActivity extends AbsTagEditorActivity implements TextW
                 lyrics.setText(getLyrics(audio.get()));
             }
         } catch (Exception e) {
-            OopsHandler.copyStackTraceToClipboard(this, e);
+            OopsHandler.copyStackTraceToClipboard(e);
         }
     }
 

--- a/app/src/main/java/com/poupa/vinylmusicplayer/util/MusicUtil.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/util/MusicUtil.java
@@ -53,7 +53,7 @@ public class MusicUtil {
         try (AutoDeleteAudioFile audio = SAFUtil.loadAudioFile(context, song)) {
             return getMediaStoreAlbumCover(audio);
         } catch (Exception e) {
-            OopsHandler.copyStackTraceToClipboard(context, e);
+            OopsHandler.copyStackTraceToClipboard(e);
             return null;
         }
     }
@@ -261,7 +261,7 @@ public class MusicUtil {
                 deleteRequestAndroidR.launch(new IntentSenderRequest.Builder(editPendingIntent).build());
             }
         } catch (SecurityException e) { // | SendIntentException e) {
-            OopsHandler.copyStackTraceToClipboard(activity, e);
+            OopsHandler.copyStackTraceToClipboard(e);
         }
 
         if (Build.VERSION.SDK_INT < VERSION_CODES.R) {
@@ -366,7 +366,7 @@ public class MusicUtil {
         try (AutoDeleteAudioFile audio = SAFUtil.loadAudioFile(context, song)) {
             lyrics = audio.get().getTagOrCreateDefault().getFirst(FieldKey.LYRICS);
         } catch (@NonNull Exception | NoSuchMethodError | VerifyError e) {
-            OopsHandler.copyStackTraceToClipboard(context, e);
+            OopsHandler.copyStackTraceToClipboard(e);
         }
 
         if (lyrics == null || lyrics.trim().isEmpty() || !AbsSynchronizedLyrics.isSynchronized(lyrics)) {
@@ -404,7 +404,7 @@ public class MusicUtil {
                     }
                 }
             } catch (Exception e) {
-                OopsHandler.copyStackTraceToClipboard(context, e);
+                OopsHandler.copyStackTraceToClipboard(e);
             }
         }
 

--- a/app/src/main/java/com/poupa/vinylmusicplayer/util/OopsHandler.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/util/OopsHandler.java
@@ -4,12 +4,14 @@ import android.content.ClipData;
 import android.content.ClipboardManager;
 import android.content.Context;
 import android.content.Intent;
+import android.os.Handler;
 import android.os.Looper;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
 
 import com.afollestad.materialdialogs.MaterialDialog;
+import com.poupa.vinylmusicplayer.App;
 import com.poupa.vinylmusicplayer.R;
 import com.poupa.vinylmusicplayer.ui.activities.bugreport.BugReportActivity;
 
@@ -76,8 +78,15 @@ public class OopsHandler implements UncaughtExceptionHandler {
         return result.toString();
     }
 
-    public static void copyStackTraceToClipboard(@NonNull final Context context, @NonNull final Throwable exception) {
-        final ClipboardManager clipboard = (ClipboardManager) context.getSystemService(Context.CLIPBOARD_SERVICE);
-        final ClipData clip = ClipData.newPlainText(context.getString(R.string.failed_to_save_playlist), OopsHandler.getStackTrace(exception));
-        clipboard.setPrimaryClip(clip);
-    }}
+    public static void copyStackTraceToClipboard(@NonNull final Throwable exception) {
+        final String stackTrace = OopsHandler.getStackTrace(exception);
+        final Context context = App.getStaticContext();
+
+        // Post the clipboard manipulation task to the main thread, since this method may be called from a non-UI thread
+        new Handler(context.getMainLooper()).post(() -> {
+            final ClipboardManager clipboard = (ClipboardManager) context.getSystemService(Context.CLIPBOARD_SERVICE);
+            final ClipData clip = ClipData.newPlainText(context.getString(R.string.app_crashed), stackTrace);
+            clipboard.setPrimaryClip(clip);
+        });
+    }
+}

--- a/app/src/main/java/com/poupa/vinylmusicplayer/util/SAFUtil.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/util/SAFUtil.java
@@ -153,7 +153,7 @@ public class SAFUtil {
             // Just ignore the jaudiotagger error on unsupported file type (Opus etc)
             return null;
         } catch (Exception e) {
-            OopsHandler.copyStackTraceToClipboard(context, e);
+            OopsHandler.copyStackTraceToClipboard(e);
             return null;
         }
     }
@@ -176,7 +176,7 @@ public class SAFUtil {
             fos.write(audioContent);
             fos.close();
         } catch (final Exception e) {
-            OopsHandler.copyStackTraceToClipboard(context, e);
+            OopsHandler.copyStackTraceToClipboard(e);
             toast(context, String.format(context.getString(R.string.saf_write_failed), e.getLocalizedMessage()));
         }
     }


### PR DESCRIPTION
Fixes https://github.com/VinylMusicPlayer/VinylMusicPlayer/issues/802

Note that this fixes the app crash, not the cause of the (diverse) exception that trigger the copy of exception to the clipboard