### PR TITLE
Fix repeat setting not being restored

### DIFF
--- a/app/src/main/java/com/poupa/vinylmusicplayer/misc/queue/StaticPlayingQueue.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/misc/queue/StaticPlayingQueue.java
@@ -48,10 +48,11 @@ public class StaticPlayingQueue {
         restoreUniqueId();
     }
 
-    public StaticPlayingQueue(ArrayList<IndexedSong> restoreQueue, ArrayList<IndexedSong> restoreOriginalQueue, int restoredPosition, int shuffleMode) {
+    public StaticPlayingQueue(ArrayList<IndexedSong> restoreQueue, ArrayList<IndexedSong> restoreOriginalQueue, int restoredPosition, int shuffleMode, int repeatMode) {
         this.queue = new ArrayList<>(restoreQueue);
         this.originalQueue = new ArrayList<>(restoreOriginalQueue);
         this.shuffleMode = shuffleMode;
+        this.repeatMode = repeatMode;
 
         currentPosition = restoredPosition;
 

--- a/app/src/main/java/com/poupa/vinylmusicplayer/service/MusicService.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/service/MusicService.java
@@ -401,7 +401,7 @@ public class MusicService extends MediaBrowserServiceCompat implements SharedPre
                 int restoredPositionInTrack = PreferenceManager.getDefaultSharedPreferences(this).getInt(SAVED_POSITION_IN_TRACK, -1);
 
                 if (restoredQueue.size() > 0 && restoredQueue.size() == restoredOriginalQueue.size() && restoredPosition != -1) {
-                    playingQueue = new StaticPlayingQueue(restoredQueue, restoredOriginalQueue, restoredPosition, playingQueue.getShuffleMode());
+                    playingQueue = new StaticPlayingQueue(restoredQueue, restoredOriginalQueue, restoredPosition, playingQueue.getShuffleMode(), playingQueue.getRepeatMode());
 
                     openCurrent();
                     prepareNext();

--- a/app/src/test/java/com/poupa/vinylmusicplayer/StaticPlayingQueueTest.java
+++ b/app/src/test/java/com/poupa/vinylmusicplayer/StaticPlayingQueueTest.java
@@ -168,7 +168,7 @@ public class StaticPlayingQueueTest {
         System.out.println("Init");
         print(test);
 
-        StaticPlayingQueue init = new StaticPlayingQueue(test.getPlayingQueue(), test.getOriginalPlayingQueue(), test.getCurrentPosition(), test.getShuffleMode());
+        StaticPlayingQueue init = new StaticPlayingQueue(test.getPlayingQueue(), test.getOriginalPlayingQueue(), test.getCurrentPosition(), test.getShuffleMode(), test.getRepeatMode());
 
         // test
         int pos = 2;


### PR DESCRIPTION
When restoring the playing queue, make sure to include the repeat setting, otherwise it will default back to none.

Fixes #663.