### PR TITLE
Use DynamicsProcessing to apply positive replay gains in a robust way

### DIFF
--- a/app/src/main/java/com/poupa/vinylmusicplayer/App.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/App.java
@@ -15,6 +15,7 @@ import com.poupa.vinylmusicplayer.discog.Discography;
  */
 public class App extends MultiDexApplication {
     public static final String TAG = App.class.getSimpleName();
+    public static final boolean DYNAMICS_PROCESSING_AVAILABLE = Build.VERSION.SDK_INT >= Build.VERSION_CODES.P;
 
     private static App app;
 

--- a/app/src/main/java/com/poupa/vinylmusicplayer/dialogs/SongDetailDialog.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/dialogs/SongDetailDialog.java
@@ -146,6 +146,14 @@ public class SongDetailDialog extends DialogFragment {
                 ? String.format(Locale.getDefault(), "%s: %.2f dB ", context.getString(R.string.album), song.replayGainAlbum)
                 : "- ";
         htmlBuilder.appendLine(R.string.label_replay_gain, rgTrack, rgAlbum);
+
+        final String rgPeakTrack = song.replayGainPeakTrack != 1.0f
+                ? String.format(Locale.getDefault(), "%s: %.2f ", context.getString(R.string.song), song.replayGainPeakTrack)
+                : "- ";
+        final String rgPeakAlbum = song.replayGainPeakAlbum != 1.0f
+                ? String.format(Locale.getDefault(), "%s: %.2f ", context.getString(R.string.album), song.replayGainPeakAlbum)
+                : "- ";
+        htmlBuilder.appendLine(R.string.label_replay_gain_peak, rgPeakTrack, rgPeakAlbum);
         discographyInfo.setText(htmlBuilder.build());
 
         return dialog;

--- a/app/src/main/java/com/poupa/vinylmusicplayer/discog/DB.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/discog/DB.java
@@ -21,7 +21,7 @@ import java.util.function.Consumer;
 
 class DB extends SQLiteOpenHelper {
     private static final String DATABASE_NAME = "discography.db";
-    private static final int VERSION = 6;
+    private static final int VERSION = 7;
 
     DB() {
         super(App.getInstance().getApplicationContext(), DATABASE_NAME, null, VERSION);
@@ -44,6 +44,8 @@ class DB extends SQLiteOpenHelper {
                         + SongColumns.GENRE +  " TEXT, "
                         + SongColumns.REPLAYGAIN_ALBUM + " REAL, "
                         + SongColumns.REPLAYGAIN_TRACK + " REAL, "
+                        + SongColumns.REPLAYGAINPEAK_ALBUM + " REAL, "
+                        + SongColumns.REPLAYGAINPEAK_TRACK + " REAL, "
                         + SongColumns.TRACK_DURATION + " LONG, "
                         + SongColumns.TRACK_NUMBER + " LONG, "
                         + SongColumns.TRACK_TITLE + " TEXT, "
@@ -81,6 +83,7 @@ class DB extends SQLiteOpenHelper {
                 case 3:
                 case 4:
                 case 5:
+                case 6:
                 case VERSION: // At target. This case is here for consistency check
                     migrateResetAll.accept(dbase);
                     break;
@@ -111,6 +114,8 @@ class DB extends SQLiteOpenHelper {
             values.put(SongColumns.GENRE, song.genre);
             values.put(SongColumns.REPLAYGAIN_ALBUM, song.replayGainAlbum);
             values.put(SongColumns.REPLAYGAIN_TRACK, song.replayGainTrack);
+            values.put(SongColumns.REPLAYGAINPEAK_ALBUM, song.replayGainPeakAlbum);
+            values.put(SongColumns.REPLAYGAINPEAK_TRACK, song.replayGainPeakTrack);
             values.put(SongColumns.TRACK_DURATION, song.duration);
             values.put(SongColumns.TRACK_NUMBER, song.trackNumber);
             values.put(SongColumns.TRACK_TITLE, song.title);
@@ -161,6 +166,8 @@ class DB extends SQLiteOpenHelper {
                         SongColumns.GENRE,
                         SongColumns.REPLAYGAIN_ALBUM,
                         SongColumns.REPLAYGAIN_TRACK,
+                        SongColumns.REPLAYGAINPEAK_ALBUM,
+                        SongColumns.REPLAYGAINPEAK_TRACK,
                         SongColumns.TRACK_DURATION,
                         SongColumns.TRACK_NUMBER,
                         SongColumns.TRACK_TITLE,
@@ -191,6 +198,8 @@ class DB extends SQLiteOpenHelper {
                 final String genre = cursor.getString(++columnIndex);
                 final float replayGainAlbum = cursor.getFloat(++columnIndex);
                 final float replayGainTrack = cursor.getFloat(++columnIndex);
+                final float replayGainPeakAlbum = cursor.getFloat(++columnIndex);
+                final float replayGainPeakTrack = cursor.getFloat(++columnIndex);
                 final long trackDuration = cursor.getLong(++columnIndex);
                 final int trackNumber = cursor.getInt(++columnIndex);
                 final String trackTitle = cursor.getString(++columnIndex);
@@ -214,6 +223,8 @@ class DB extends SQLiteOpenHelper {
                 song.genre = genre;
                 song.replayGainTrack = replayGainTrack;
                 song.replayGainAlbum = replayGainAlbum;
+                song.replayGainPeakTrack = replayGainPeakTrack;
+                song.replayGainPeakAlbum = replayGainPeakAlbum;
 
                 songs.add(song);
             } while (cursor.moveToNext());
@@ -237,6 +248,8 @@ class DB extends SQLiteOpenHelper {
         String GENRE = "genre";
         String REPLAYGAIN_ALBUM = "replaygain_album";
         String REPLAYGAIN_TRACK = "replaygain_track";
+        String REPLAYGAINPEAK_ALBUM = "replaygainpeak_album";
+        String REPLAYGAINPEAK_TRACK = "replaygainpeak_track";
         String TRACK_DURATION = "track_duration";
         String TRACK_TITLE = "track_title";
         String TRACK_NUMBER = "track_number";

--- a/app/src/main/java/com/poupa/vinylmusicplayer/discog/Discography.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/discog/Discography.java
@@ -289,6 +289,10 @@ public class Discography implements MusicServiceEventListener {
         }
     }
 
+    public float getMaxReplayGain() {
+        return cache.getMaxReplayGain();
+    }
+
     private void addSong(@NonNull Song song, boolean cacheOnly) {
         synchronized (cache) {
             // Race condition check: If the song has been added -> skip

--- a/app/src/main/java/com/poupa/vinylmusicplayer/discog/tagging/TagExtractor.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/discog/tagging/TagExtractor.java
@@ -87,6 +87,8 @@ public class TagExtractor {
             ReplayGainTagExtractor.ReplayGainValues rgValues = ReplayGainTagExtractor.setReplayGainValues(file);
             song.replayGainAlbum = rgValues.album;
             song.replayGainTrack = rgValues.track;
+            song.replayGainPeakAlbum = rgValues.peakAlbum;
+            song.replayGainPeakTrack = rgValues.peakTrack;
         } catch (@NonNull Exception | NoSuchMethodError | VerifyError e) {
             OopsHandler.copyStackTraceToClipboard(e);
         }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/model/Song.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/model/Song.java
@@ -37,6 +37,8 @@ public class Song implements Parcelable {
     public String genre = "";
     public float replayGainAlbum = 0;
     public float replayGainTrack = 0;
+    public float replayGainPeakAlbum = 1.0f;
+    public float replayGainPeakTrack = 1.0f;
     public String title;
     public int trackNumber;
     public int year;
@@ -73,6 +75,8 @@ public class Song implements Parcelable {
         this.genre = song.genre;
         this.replayGainAlbum = song.replayGainAlbum;
         this.replayGainTrack = song.replayGainTrack;
+        this.replayGainPeakAlbum = song.replayGainPeakAlbum;
+        this.replayGainPeakTrack = song.replayGainPeakTrack;
         this.title = song.title;
         this.trackNumber = song.trackNumber;
         this.year = song.year;

--- a/app/src/main/java/com/poupa/vinylmusicplayer/service/MultiPlayer.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/service/MultiPlayer.java
@@ -200,6 +200,10 @@ public class MultiPlayer implements Playback, MediaPlayer.OnErrorListener, Media
         if (mNextMediaPlayer != null) {
             mNextMediaPlayer.release();
         }
+        if (mDynamicsProcessing != null) {
+            mDynamicsProcessing.release();
+            mDynamicsProcessing = null;
+        }
     }
 
     /**

--- a/app/src/main/java/com/poupa/vinylmusicplayer/service/MultiPlayer.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/service/MultiPlayer.java
@@ -8,13 +8,13 @@ import android.media.MediaPlayer;
 import android.media.audiofx.AudioEffect;
 import android.media.audiofx.DynamicsProcessing;
 import android.net.Uri;
-import android.os.Build;
 import android.os.PowerManager;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.poupa.vinylmusicplayer.App;
 import com.poupa.vinylmusicplayer.R;
 import com.poupa.vinylmusicplayer.service.playback.Playback;
 import com.poupa.vinylmusicplayer.util.PreferenceUtil;
@@ -84,7 +84,7 @@ public class MultiPlayer implements Playback, MediaPlayer.OnErrorListener, Media
                 player.setDataSource(path);
             }
             player.setAudioStreamType(AudioManager.STREAM_MUSIC);
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P && mDynamicsProcessing == null) {
+            if (App.DYNAMICS_PROCESSING_AVAILABLE && mDynamicsProcessing == null) {
                 mDynamicsProcessing = new DynamicsProcessing(player.getAudioSessionId());
                 mDynamicsProcessing.setEnabled(true);
             }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/service/MultiPlayer.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/service/MultiPlayer.java
@@ -297,15 +297,21 @@ public class MultiPlayer implements Playback, MediaPlayer.OnErrorListener, Media
         return mCurrentMediaPlayer.getAudioSessionId();
     }
 
+    /**
+     * Set the replay gain to be applied immediately. It should match the tags of the current song.
+     *
+     * @param replaygain gain in dB, or NaN for no replay gain (equivalent to 0dB)
+     */
     public void setReplayGain(float replaygain) {
-        if (Float.isNaN(replaygain)) {
-            this.replaygain = Float.NaN;
-        } else {
-            this.replaygain = Math.max(0, Math.min(1, replaygain));
-        }
+        this.replaygain = replaygain;
         updateVolume();
     }
 
+    /**
+     * Set the ducking factor to be applied immediately.
+     *
+     * @param duckingFactor gain as a linear factor, between 0.0 and 1.0.
+     */
     public void setDuckingFactor(float duckingFactor) {
         this.duckingFactor = duckingFactor;
         updateVolume();
@@ -314,7 +320,9 @@ public class MultiPlayer implements Playback, MediaPlayer.OnErrorListener, Media
     private void updateVolume() {
         float volume = 1.0f;
         if (!Float.isNaN(replaygain)) {
-            volume = replaygain;
+            // setVolume uses a linear scale
+            float rgResult = ((float) Math.pow(10, (replaygain / 20)));
+            volume = Math.max(0, Math.min(1, rgResult));
         }
 
         volume *= duckingFactor;

--- a/app/src/main/java/com/poupa/vinylmusicplayer/service/MultiPlayer.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/service/MultiPlayer.java
@@ -298,7 +298,11 @@ public class MultiPlayer implements Playback, MediaPlayer.OnErrorListener, Media
     }
 
     public void setReplayGain(float replaygain) {
-        this.replaygain = replaygain;
+        if (Float.isNaN(replaygain)) {
+            this.replaygain = Float.NaN;
+        } else {
+            this.replaygain = Math.max(0, Math.min(1, replaygain));
+        }
         updateVolume();
     }
 

--- a/app/src/main/java/com/poupa/vinylmusicplayer/service/MultiPlayer.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/service/MultiPlayer.java
@@ -311,6 +311,7 @@ public class MultiPlayer implements Playback, MediaPlayer.OnErrorListener, Media
      *
      * @param replaygain gain in dB, or NaN for no replay gain (equivalent to 0dB)
      */
+    @Override
     public void setReplayGain(float replaygain) {
         this.replaygain = replaygain;
         updateVolume();
@@ -321,6 +322,7 @@ public class MultiPlayer implements Playback, MediaPlayer.OnErrorListener, Media
      *
      * @param duckingFactor gain as a linear factor, between 0.0 and 1.0.
      */
+    @Override
     public void setDuckingFactor(float duckingFactor) {
         this.duckingFactor = duckingFactor;
         updateVolume();

--- a/app/src/main/java/com/poupa/vinylmusicplayer/service/MusicService.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/service/MusicService.java
@@ -893,25 +893,36 @@ public class MusicService extends MediaBrowserServiceCompat implements SharedPre
         if (mode != PreferenceUtil.RG_SOURCE_MODE_NONE) {
             Song song = getCurrentSong();
 
-            float adjust = 0f;
+            float adjustDB = 0f;
+            float peak = 1.0f;
+
             float rgTrack = song.replayGainTrack;
             float rgAlbum = song.replayGainAlbum;
+            float rgpTrack = song.replayGainPeakTrack;
+            float rgpAlbum = song.replayGainPeakAlbum;
 
             if (mode == PreferenceUtil.RG_SOURCE_MODE_ALBUM) {
-                adjust = (rgTrack != 0 ? rgTrack : adjust);
-                adjust = (rgAlbum != 0 ? rgAlbum : adjust);
+                adjustDB = (rgTrack != 0 ? rgTrack : adjustDB);
+                adjustDB = (rgAlbum != 0 ? rgAlbum : adjustDB);
+                peak = (rgpTrack != 1.0f ? rgpTrack : peak);
+                peak = (rgpAlbum != 1.0f ? rgpAlbum : peak);
             } else if (mode == PreferenceUtil.RG_SOURCE_MODE_TRACK) {
-                adjust = (rgAlbum != 0 ? rgAlbum : adjust);
-                adjust = (rgTrack != 0 ? rgTrack : adjust);
+                adjustDB = (rgAlbum != 0 ? rgAlbum : adjustDB);
+                adjustDB = (rgTrack != 0 ? rgTrack : adjustDB);
+                peak = (rgpAlbum != 1.0f ? rgpAlbum : peak);
+                peak = (rgpTrack != 1.0f ? rgpTrack : peak);
             }
 
-            if (adjust == 0) {
-                adjust = PreferenceUtil.getInstance().getRgPreampWithoutTag();
+            if (adjustDB == 0) {
+                adjustDB = PreferenceUtil.getInstance().getRgPreampWithoutTag();
             } else {
-                adjust += PreferenceUtil.getInstance().getRgPreampWithTag();
+                adjustDB += PreferenceUtil.getInstance().getRgPreampWithTag();
+
+                float peakDB = -20.0f * ((float) Math.log10(peak));
+                adjustDB = Math.min(adjustDB, peakDB);
             }
 
-            playback.setReplayGain(adjust);
+            playback.setReplayGain(adjustDB);
         } else {
             playback.setReplayGain(Float.NaN);
         }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/service/MusicService.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/service/MusicService.java
@@ -912,7 +912,6 @@ public class MusicService extends MediaBrowserServiceCompat implements SharedPre
             }
 
             float rgResult = ((float) Math.pow(10, (adjust / 20)));
-            rgResult = Math.max(0, Math.min(1, rgResult));
 
             playback.setReplayGain(rgResult);
         } else {

--- a/app/src/main/java/com/poupa/vinylmusicplayer/service/MusicService.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/service/MusicService.java
@@ -911,9 +911,7 @@ public class MusicService extends MediaBrowserServiceCompat implements SharedPre
                 adjust += PreferenceUtil.getInstance().getRgPreampWithTag();
             }
 
-            float rgResult = ((float) Math.pow(10, (adjust / 20)));
-
-            playback.setReplayGain(rgResult);
+            playback.setReplayGain(adjust);
         } else {
             playback.setReplayGain(Float.NaN);
         }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/util/PreferenceUtil.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/util/PreferenceUtil.java
@@ -6,6 +6,7 @@ import android.content.res.Configuration;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.net.Uri;
+import android.os.Build;
 import android.preference.PreferenceManager;
 
 import androidx.annotation.NonNull;
@@ -725,12 +726,23 @@ public final class PreferenceUtil {
         return sourceMode;
     }
 
+    private float getDefaultPreamp() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {
+            // Older android versions cannot use DynamicsProcessing, so MultiPlayer uses the volume instead.
+            // Use a default preamp that allows increasing the sound of the most quiet song in the DB.
+            // Kept in the range -6dB..0dB to ensure we don't make everything too quiet only because of 1 outlier song.
+            return Math.max(-6.0f, Math.min(-App.getDiscography().getMaxReplayGain(), 0f));
+        } else {
+            return 0.0f;
+        }
+    }
+
     public float getRgPreampWithTag() {
-        return mPreferences.getFloat(RG_PREAMP_WITH_TAG, 0.0f);
+        return mPreferences.getFloat(RG_PREAMP_WITH_TAG, getDefaultPreamp());
     }
 
     public float getRgPreampWithoutTag() {
-        return mPreferences.getFloat(RG_PREAMP_WITHOUT_TAG, 0.0f);
+        return mPreferences.getFloat(RG_PREAMP_WITHOUT_TAG, getDefaultPreamp());
     }
 
     public void setReplayGainPreamp(float with, float without) {

--- a/app/src/main/java/com/poupa/vinylmusicplayer/util/PreferenceUtil.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/util/PreferenceUtil.java
@@ -727,7 +727,7 @@ public final class PreferenceUtil {
     }
 
     private float getDefaultPreamp() {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {
+        if (!App.DYNAMICS_PROCESSING_AVAILABLE) {
             // Older android versions cannot use DynamicsProcessing, so MultiPlayer uses the volume instead.
             // Use a default preamp that allows increasing the sound of the most quiet song in the DB.
             // Kept in the range -6dB..0dB to ensure we don't make everything too quiet only because of 1 outlier song.

--- a/app/src/main/java/com/poupa/vinylmusicplayer/util/SAFUtil.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/util/SAFUtil.java
@@ -149,7 +149,7 @@ public class SAFUtil {
                 if (i == -1) {return "";}
                 return name.substring(i + 1);
             };
-            File tempFile = AutoDeleteTempFile.create(String.valueOf(song.id), getSuffix.apply(song.data)).get();
+            File tempFile = AutoDeleteTempFile.create("song-" + song.id, getSuffix.apply(song.data)).get();
 
             // Copy the content of the URI to the temp file
             try (OutputStream temp = new FileOutputStream(tempFile)) {

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -89,6 +89,7 @@
     <string name="label_track_length">Durée</string>
     <string name="label_bit_rate">Débit</string>
     <string name="label_sampling_rate">Taux d\'échantillonnage</string>
+    <string name="label_replay_gain_peak">Pic ReplayGain</string>
     <string name="label_date_added">Ajouté</string>
     <string name="label_date_modified">Modifié</string>
     <string name="label_playing_queue">File de lecture</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -72,6 +72,7 @@
     <string name="label_bit_rate">Bitrate</string>
     <string name="label_sampling_rate">Sampling rate</string>
     <string name="label_replay_gain" translatable="false">ReplayGain</string>
+    <string name="label_replay_gain_peak">ReplayGain peak</string>
     <string name="label_date_added">Added</string>
     <string name="label_date_modified">Modified</string>
     <string name="action_go_to_artist">Go to artist</string>


### PR DESCRIPTION
As mentioned in #785, positive replay gains were not applied reliably, because MediaPlay.setVolume only accepts values between 0.0 and 1.0.
This PR introduces DynamicsProcessing in the MultiPlayer: it allows both positive and negative gains on its input gain stage, so there is no need to reduce the replay gain preamp value in the settings any more to benefit from positive replay gains.

DynamicsProcessing is only available from Android P, so the volume-based method is still used for older phones. In this case, the conversion from dB to linear gain has been moved from the MusicService into the MultiPlayer, since DynamicsProcessing input gain takes values in dB.

Also, as per the [ReplayGain spec](https://wiki.hydrogenaud.io/index.php?title=ReplayGain_1.0_specification#Reduced_gain), the replay gain applied is now capped from the information present in the replay gain peak tags of the songs.
I'm not 100% sure this is a required thing to do, and it impacts a fair bit of code since the peak info was not available in the song DB until now. Let me know if you'd prefer cancelling this part of the PR.

To test all this, I've used the Android emulator with MP3 files that have the same white noise at the same level, but different replay gain tags (-6dB, +6dB, 0dB are easy to hear). I can share these if you think they'd be useful to check this PR.