### PR TITLE
Fix equalizer settings being marked unavailable in the settings

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,6 +19,10 @@
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
+    <queries>
+        <package android:name="com.android.musicfx" />
+    </queries>
+
     <!-- android:requestLegacyExternalStorage="true" is only used for android 10 (api 29)
     and lower if app is build for android 11 or up (>= 30, aka VERSION_CODES.R)
     => https://developer.android.com/training/data-storage/use-cases#opt-out-in-production-app -->


### PR DESCRIPTION
Item was showing "No equalizer found."
Tomcat was showing e.g.:
```
AppsFilter system_server I interaction: PackageSetting{2ed00e2 com.poupa.vinylmusicplayer.ci.debug/10125} -> PackageSetting{2d494d8 com.android.musicfx/10062} BLOCKED
```