### PR TITLE
Fix FileNotFoundException popups on Android 13 (API 33+)

### DIFF
--- a/app/src/main/java/com/poupa/vinylmusicplayer/glide/audiocover/AbsCoverFetcher.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/glide/audiocover/AbsCoverFetcher.java
@@ -42,7 +42,7 @@ public abstract class AbsCoverFetcher implements DataFetcher<InputStream> {
         File parent = file.getParentFile();
         for (String fallback : FALLBACKS) {
             File cover = new File(parent, fallback);
-            if (cover.exists()) {
+            if (cover.exists() && cover.canRead()) {
                 return stream = new FileInputStream(cover);
             }
         }


### PR DESCRIPTION
READ_MEDIA_IMAGES does not seem to be enough to read jpg files in the audio folders. Check a file is readable before reading it to avoid a permission-related FileNotFoundException.

This is just a quick fix to remove the exception until a better way to read the cover art files is found (#816).