### PR TITLE
Fix tag editor on Android R (11) and later

### DIFF
--- a/app/src/main/java/com/poupa/vinylmusicplayer/helper/menu/MenuHelper.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/helper/menu/MenuHelper.java
@@ -11,6 +11,7 @@ import androidx.annotation.ColorInt;
 import androidx.annotation.NonNull;
 
 import com.poupa.vinylmusicplayer.R;
+import com.poupa.vinylmusicplayer.ui.activities.tageditor.AbsTagEditorActivity;
 
 public class MenuHelper {
     public static void decorateDestructiveItems(@NonNull final Menu menu, final Context context) {
@@ -30,6 +31,13 @@ public class MenuHelper {
 
             span.setSpan(new ForegroundColorSpan(color), 0, span.length(), 0);
             liveItem.setTitle(span);
+        }
+    }
+
+    public static void showTagEditorIfAvailable(@NonNull final Menu menu) {
+        var tagEditorItem = menu.findItem(R.id.action_tag_editor);
+        if (tagEditorItem != null) {
+            tagEditorItem.setVisible(AbsTagEditorActivity.AVAILABLE);
         }
     }
 }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/helper/menu/SongMenuHelper.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/helper/menu/SongMenuHelper.java
@@ -90,6 +90,7 @@ public class SongMenuHelper {
             popupMenu.setOnMenuItemClickListener(this);
 
             MenuHelper.decorateDestructiveItems(popupMenu.getMenu(), v.getContext());
+            MenuHelper.showTagEditorIfAvailable(popupMenu.getMenu());
 
             popupMenu.show();
         }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/AlbumDetailActivity.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/AlbumDetailActivity.java
@@ -224,6 +224,7 @@ public class AlbumDetailActivity
         getMenuInflater().inflate(R.menu.menu_album_detail, menu);
 
         MenuHelper.decorateDestructiveItems(menu, this);
+        MenuHelper.showTagEditorIfAvailable(menu);
 
         return super.onCreateOptionsMenu(menu);
     }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/tageditor/AbsTagEditorActivity.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/tageditor/AbsTagEditorActivity.java
@@ -360,26 +360,16 @@ public abstract class AbsTagEditorActivity extends AbsBaseActivity {
         savedTags = fieldKeyValueMap;
         savedArtworkInfo = artworkInfo;
 
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
-            if (!SAFUtil.isSAFRequired(savedSongs)) {
-                writeTags(savedSongs);
-            } else {
-                writeTagsApi19();
-            }
+        if (!SAFUtil.isSAFRequired(savedSongs)) {
+            writeTags(savedSongs);
+        } else if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+            writeTagsApi19();
+        } else if (SAFUtil.isSDCardAccessGranted(this)) {
+            writeTags(savedSongs);
         } else if (Build.VERSION.SDK_INT < VERSION_CODES.R) {
-            if (!SAFUtil.isSAFRequired(savedSongs)) {
-                writeTags(savedSongs);
-            } else if (SAFUtil.isSDCardAccessGranted(this)) {
-                writeTags(savedSongs);
-            } else {
-                writeTagsApi21_SAFGuide.launch(new Intent(this, SAFGuideActivity.class));
-            }
+            writeTagsApi21_SAFGuide.launch(new Intent(this, SAFGuideActivity.class));
         } else {
-            if (SAFUtil.isSDCardAccessGranted(this)) {
-                writeTags(savedSongs);
-            } else {
-                writeTagsApi30();
-            }
+            writeTagsApi30();
         }
     }
 

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/tageditor/AbsTagEditorActivity.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/tageditor/AbsTagEditorActivity.java
@@ -73,6 +73,8 @@ public abstract class AbsTagEditorActivity extends AbsBaseActivity {
 
     public static final String EXTRA_ID = "extra_id";
     public static final String EXTRA_PALETTE = "extra_palette";
+    // AudioIO crashes before Android O - Disable this editor for older versions
+    public static final boolean AVAILABLE = Build.VERSION.SDK_INT >= VERSION_CODES.O;
 
     FloatingActionButton fab;
     ObservableScrollView observableScrollView;

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/tageditor/AbsTagEditorActivity.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/tageditor/AbsTagEditorActivity.java
@@ -362,7 +362,7 @@ public abstract class AbsTagEditorActivity extends AbsBaseActivity {
 
         if (!SAFUtil.isSAFRequired(savedSongs)) {
             writeTags(savedSongs);
-        } else if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+        } else if (Build.VERSION.SDK_INT < VERSION_CODES.LOLLIPOP) {
             writeTagsApi19();
         } else if (SAFUtil.isSDCardAccessGranted(this)) {
             writeTags(savedSongs);

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/fragments/mainactivity/folders/FoldersFragment.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/fragments/mainactivity/folders/FoldersFragment.java
@@ -38,6 +38,7 @@ import com.poupa.vinylmusicplayer.R;
 import com.poupa.vinylmusicplayer.adapter.SongFileAdapter;
 import com.poupa.vinylmusicplayer.databinding.FragmentFolderBinding;
 import com.poupa.vinylmusicplayer.helper.MusicPlayerRemote;
+import com.poupa.vinylmusicplayer.helper.menu.MenuHelper;
 import com.poupa.vinylmusicplayer.helper.menu.SongMenuHelper;
 import com.poupa.vinylmusicplayer.helper.menu.SongsMenuHelper;
 import com.poupa.vinylmusicplayer.interfaces.CabCallbacks;
@@ -419,6 +420,7 @@ public class FoldersFragment
             });
         } else {
             popupMenu.inflate(R.menu.menu_item_file);
+            MenuHelper.showTagEditorIfAvailable(popupMenu.getMenu());
             popupMenu.setOnMenuItemClickListener(item -> {
                 final int itemId = item.getItemId();
                 if (itemId == R.id.action_play_next


### PR DESCRIPTION
Simply moved the call to the new Android R `MediaStore.createWriteRequest` to `writeValuesToFiles`, in the case where SD Card access is not granted.

I've also reworked the logic in `writeValuesToFiles` to make it more linear.

Need to double-check everything is fine on these Android versions:

- [ ] Prior to Lollipop
- [x] Lollipop+ (but prior to R) (tested on Oreo)
- [x] R+ (tested on Tiramisu)