### PR TITLE
Use an updated fork with Opus support

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -180,7 +180,7 @@ dependencies {
 
     implementation 'me.zhanghai.android.materialprogressbar:library:1.6.1'
 
-    implementation 'net.jthink:jaudiotagger:3.0.1'
+    implementation 'com.github.VinylMusicPlayer:jaudiotagger:v3.0.1o'
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 


### PR DESCRIPTION
This fork supports reading metadata from Opus files
Opus support backported from https://github.com/Kaned1as/jaudiotagger

Fixes: #780, #781