### PR TITLE
fixes #853, the system UI notification crash

### DIFF
--- a/app/src/main/java/com/poupa/vinylmusicplayer/service/notification/PlayingNotificationImplApi24.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/service/notification/PlayingNotificationImplApi24.java
@@ -106,8 +106,17 @@ public class PlayingNotificationImplApi24 extends PlayingNotification {
                                 .addAction(favoriteAction);
 
                         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-                            builder.setStyle(new MediaStyle().setMediaSession(service.getMediaSession().getSessionToken()).setShowActionsInCompactView(0, 1, 2))
-                                    .setVisibility(NotificationCompat.VISIBILITY_PUBLIC);
+                            var session = service.getMediaSession();
+                            var controller = session.getController();
+
+                            // workaround for a bug https://github.com/VinylMusicPlayer/VinylMusicPlayer/issues/853
+                            // it's possible that the mediaSession's metadata is still null at this point,
+                            // which can lead to a system UI crash on certain versions of android
+                            if (controller != null && controller.getMetadata() != null) {
+                                builder.setStyle(new MediaStyle().setMediaSession(session.getSessionToken()).setShowActionsInCompactView(0, 1, 2))
+                                        .setVisibility(NotificationCompat.VISIBILITY_PUBLIC);
+                            }
+
                             if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.O && PreferenceUtil.getInstance().coloredNotification())
                                 builder.setColor(color);
                         }


### PR DESCRIPTION
@soncaokim It turned out the problem was with the fancy notification grabbing the mediaSession before a metadata had been set.  My change does the simplest thing I could think of to prevent this.  It just checks to make sure the metadata isn't null when building the notification.

I tested this on my phone and it prevents the crash.  The only downside seems to be that the notification control thing isn't fancy, until you hit play, at which point it restyles itself.

The precise steps to reproduce look like this:
1. uninstall app
2. install app
3. let it build library enough to find a song
4. play a few seconds of the song
5. pause the song
6. close the app
7. reopen the app

This always crashed the system UI before, and with this patch, it no longer crashes.

FWIW, the reason your changes to MusicService.java didn't fix the problem is because those parts of the code weren't called before the code in PlayingNotificationImplApi24.java was being called.

fixes #853 