### PR TITLE
Add context menu to genre activity

### DIFF
--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/GenreDetailActivity.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/GenreDetailActivity.java
@@ -23,6 +23,7 @@ import com.poupa.vinylmusicplayer.R;
 import com.poupa.vinylmusicplayer.adapter.song.SongAdapter;
 import com.poupa.vinylmusicplayer.databinding.ActivityGenreDetailBinding;
 import com.poupa.vinylmusicplayer.databinding.SlidingMusicPanelLayoutBinding;
+import com.poupa.vinylmusicplayer.dialogs.AddToPlaylistDialog;
 import com.poupa.vinylmusicplayer.helper.MusicPlayerRemote;
 import com.poupa.vinylmusicplayer.interfaces.CabCallbacks;
 import com.poupa.vinylmusicplayer.interfaces.CabHolder;
@@ -115,8 +116,18 @@ public class GenreDetailActivity extends AbsSlidingMusicPanelActivity implements
     @Override
     public boolean onOptionsItemSelected(@NonNull MenuItem item) {
         final int id = item.getItemId();
-        if (id == R.id.action_shuffle_genre) {
-            MusicPlayerRemote.openAndShuffleQueue(adapter.getDataSet(), true);
+        final ArrayList<Song> songs = adapter.getDataSet();
+        if (id == R.id.action_add_to_current_playing) {
+            MusicPlayerRemote.enqueue(songs);
+            return true;
+        } else if (id == R.id.action_add_to_playlist) {
+            AddToPlaylistDialog.create(songs).show(getSupportFragmentManager(), "ADD_PLAYLIST");
+            return true;
+        } else if (id == R.id.action_play_next) {
+            MusicPlayerRemote.playNext(songs);
+            return true;
+        } else if (id == R.id.action_shuffle_genre) {
+            MusicPlayerRemote.openAndShuffleQueue(songs, true);
             return true;
         } else if (id == android.R.id.home) {
             onBackPressed();

--- a/app/src/main/res/menu/menu_genre_detail.xml
+++ b/app/src/main/res/menu/menu_genre_detail.xml
@@ -9,4 +9,19 @@
         android:title="@string/action_shuffle_all"
         app:showAsAction="ifRoom" />
 
+    <item
+        android:id="@+id/action_play_next"
+        android:title="@string/action_play_next"
+        app:showAsAction="never" />
+
+    <item
+        android:id="@+id/action_add_to_current_playing"
+        android:title="@string/action_add_to_playing_queue"
+        app:showAsAction="never" />
+
+    <item
+        android:id="@+id/action_add_to_playlist"
+        android:title="@string/action_add_to_playlist"
+        app:showAsAction="never" />
+
 </menu>


### PR DESCRIPTION
Add context menu to genre activity

- Play Next
- Add to playing queue
- Add to playlist...

This adds identical functionality for genres to these 3 features found in artist play activity.
This is related to #906 and implements my desired functionality.