### PR TITLE
Allow tag editor to function on API 30+

### DIFF
--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/tageditor/AbsTagEditorActivity.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/tageditor/AbsTagEditorActivity.java
@@ -377,17 +377,13 @@ public abstract class AbsTagEditorActivity extends AbsBaseActivity {
             } else {
                 writeTagsApi19();
             }
-        } else if (Build.VERSION.SDK_INT < VERSION_CODES.R) {
+        } else {
             if (!SAFUtil.isSAFRequired(savedSongs)) {
                 writeTags(savedSongs);
             } else if (SAFUtil.isSDCardAccessGranted(this)) {
                 writeTags(savedSongs);
             } else {
                 writeTagsApi21_SAFGuide.launch(new Intent(this, SAFGuideActivity.class));
-            }
-        } else {
-            if (SAFUtil.isSDCardAccessGranted(this)) {
-                writeTags(savedSongs);
             }
         }
     }


### PR DESCRIPTION
Re: #863

In all technicality, this check does nothing and has no side effects. We don't gate solely on SD card access for other API versions, and the checking state to request any necessary permissions for the code occurs elsewhere. So we should not do this check here.