### PR TITLE
Fix crash on select dupe song in playlist

### DIFF
--- a/app/src/main/java/com/poupa/vinylmusicplayer/adapter/AlbumCoverPagerAdapter.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/adapter/AlbumCoverPagerAdapter.java
@@ -20,6 +20,7 @@ import com.poupa.vinylmusicplayer.misc.CustomFragmentStatePagerAdapter;
 import com.poupa.vinylmusicplayer.model.Song;
 
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author Karim Abou Zeid (kabouzeid)
@@ -31,7 +32,7 @@ public class AlbumCoverPagerAdapter extends CustomFragmentStatePagerAdapter {
     private AlbumCoverFragment.ColorReceiver currentColorReceiver;
     private int currentColorReceiverPosition = -1;
 
-    public AlbumCoverPagerAdapter(FragmentManager fm, ArrayList<Song> dataSet) {
+    public AlbumCoverPagerAdapter(FragmentManager fm, List<? extends Song> dataSet) {
         super(fm);
         // Make a copy to avoid race condition
         // i.e. the playing queue is modified, the UI code detects the change and crash

--- a/app/src/main/java/com/poupa/vinylmusicplayer/adapter/song/AbsOffsetSongAdapter.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/adapter/song/AbsOffsetSongAdapter.java
@@ -26,8 +26,8 @@ import java.util.List;
  */
 public abstract class AbsOffsetSongAdapter extends SongAdapter {
 
-    protected static final int OFFSET_ITEM = 0;
-    protected static final int SONG = 1;
+    static final int OFFSET_ITEM = 0;
+    private static final int SONG = 1;
 
     // Need to be different from RecyclerView.NO_ID to not to upset the base class
     protected static final long OFFSET_ITEM_ID = RecyclerView.NO_ID - 1;
@@ -46,9 +46,9 @@ public abstract class AbsOffsetSongAdapter extends SongAdapter {
 
     @NonNull
     @Override
-    public SongAdapter.ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+    public SongAdapter.ViewHolder onCreateViewHolder(@NonNull final ViewGroup parent, final int viewType) {
         if (viewType == OFFSET_ITEM) {
-            ItemListSingleRowBinding binding = ItemListSingleRowBinding.inflate(LayoutInflater.from(activity), parent, false);
+            final ItemListSingleRowBinding binding = ItemListSingleRowBinding.inflate(LayoutInflater.from(activity), parent, false);
             return createViewHolder(binding);
         }
         return super.onCreateViewHolder(parent, viewType);
@@ -56,28 +56,29 @@ public abstract class AbsOffsetSongAdapter extends SongAdapter {
 
     @NonNull
     @Override
-    protected SongAdapter.ViewHolder createViewHolder(@NonNull ItemListSingleRowBinding binding) {
+    protected SongAdapter.ViewHolder createViewHolder(@NonNull final ItemListSingleRowBinding binding) {
         return new AbsOffsetSongAdapter.ViewHolder(binding);
     }
 
     @NonNull
     @Override
-    protected SongAdapter.ViewHolder createViewHolder(@NonNull ItemListBinding binding) {
+    protected SongAdapter.ViewHolder createViewHolder(@NonNull final ItemListBinding binding) {
         return new AbsOffsetSongAdapter.ViewHolder(binding);
     }
 
     @NonNull
     @Override
-    protected SongAdapter.ViewHolder createViewHolder(@NonNull ItemGridBinding binding) {
+    protected SongAdapter.ViewHolder createViewHolder(@NonNull final ItemGridBinding binding) {
         return new AbsOffsetSongAdapter.ViewHolder(binding);
     }
 
     @Override
-    public long getItemId(int position) {
+    public long getItemId(final int position) {
         // Shifting by -1, since the very first item is the OFFSET_ITEM
-        position--;
+        final int adjustedPosition = position - 1;
+        if (adjustedPosition < 0) {return OFFSET_ITEM_ID;}
 
-        return (position < 0 ? OFFSET_ITEM_ID : super.getItemId(position));
+        return super.getItemId(adjustedPosition);
     }
 
     @Nullable
@@ -95,7 +96,7 @@ public abstract class AbsOffsetSongAdapter extends SongAdapter {
     }
 
     @Override
-    public int getItemViewType(int position) {
+    public int getItemViewType(final int position) {
         return position == 0 ? OFFSET_ITEM : SONG;
     }
 
@@ -108,27 +109,29 @@ public abstract class AbsOffsetSongAdapter extends SongAdapter {
     }
 
     public class ViewHolder extends SongAdapter.ViewHolder {
-        public ViewHolder(@NonNull ItemListSingleRowBinding binding) {
+        public ViewHolder(@NonNull final ItemListSingleRowBinding binding) {
             super(binding);
         }
 
-        public ViewHolder(@NonNull ItemListBinding binding) {
+        public ViewHolder(@NonNull final ItemListBinding binding) {
             super(binding);
         }
 
-        public ViewHolder(@NonNull ItemGridBinding binding) {
+        public ViewHolder(@NonNull final ItemGridBinding binding) {
             super(binding);
         }
 
+        @NonNull
         @Override
         protected Song getSong() {
-            if (getItemViewType() == OFFSET_ITEM)
-                return Song.EMPTY_SONG; // could also return null, just to be safe return empty song
+            if (getItemViewType() == OFFSET_ITEM) {
+                return Song.EMPTY_SONG;
+            }
             return dataSet.get(getBindingAdapterPosition() - 1);
         }
 
         @Override
-        public void onClick(View v) {
+        public void onClick(final View v) {
             if (isInQuickSelectMode() && getItemViewType() != OFFSET_ITEM) {
                 toggleChecked(getBindingAdapterPosition());
             } else {
@@ -137,7 +140,7 @@ public abstract class AbsOffsetSongAdapter extends SongAdapter {
         }
 
         @Override
-        public boolean onLongClick(View view) {
+        public boolean onLongClick(final View view) {
             if (getItemViewType() == OFFSET_ITEM) return false;
             setColor(ThemeStore.primaryColor(activity));
             toggleChecked(getBindingAdapterPosition());

--- a/app/src/main/java/com/poupa/vinylmusicplayer/adapter/song/AbsOffsetSongAdapter.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/adapter/song/AbsOffsetSongAdapter.java
@@ -19,7 +19,7 @@ import com.poupa.vinylmusicplayer.helper.MusicPlayerRemote;
 import com.poupa.vinylmusicplayer.interfaces.CabHolder;
 import com.poupa.vinylmusicplayer.model.Song;
 
-import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author Eugene Cheung (arkon)
@@ -32,12 +32,15 @@ public abstract class AbsOffsetSongAdapter extends SongAdapter {
     // Need to be different from RecyclerView.NO_ID to not to upset the base class
     protected static final long OFFSET_ITEM_ID = RecyclerView.NO_ID - 1;
 
-    public AbsOffsetSongAdapter(AppCompatActivity activity, ArrayList<Song> dataSet, @LayoutRes int itemLayoutRes, boolean usePalette, @Nullable CabHolder cabHolder) {
+    public AbsOffsetSongAdapter(final AppCompatActivity activity, final List<? extends Song> dataSet,
+                                @LayoutRes final int itemLayoutRes,
+                                final boolean usePalette, @Nullable final CabHolder cabHolder) {
         super(activity, dataSet, itemLayoutRes, usePalette, cabHolder);
     }
 
-    public AbsOffsetSongAdapter(AppCompatActivity activity, ArrayList<Song> dataSet, boolean usePalette,
-                                @Nullable CabHolder cabHolder, boolean showSectionName) {
+    public AbsOffsetSongAdapter(final AppCompatActivity activity, final List<? extends Song> dataSet,
+                                final boolean usePalette, @Nullable final CabHolder cabHolder,
+                                final boolean showSectionName) {
         super(activity, dataSet, R.layout.item_list, usePalette, cabHolder, showSectionName);
     }
 

--- a/app/src/main/java/com/poupa/vinylmusicplayer/adapter/song/OrderablePlaylistSongAdapter.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/adapter/song/OrderablePlaylistSongAdapter.java
@@ -9,7 +9,6 @@ import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.AppCompatImageView;
 
 import com.h6ah4i.android.widget.advrecyclerview.draggable.DraggableItemAdapter;
-import com.h6ah4i.android.widget.advrecyclerview.draggable.DraggableItemViewHolder;
 import com.h6ah4i.android.widget.advrecyclerview.draggable.ItemDraggableRange;
 import com.h6ah4i.android.widget.advrecyclerview.draggable.annotation.DraggableItemStateFlags;
 import com.poupa.vinylmusicplayer.R;
@@ -35,10 +34,10 @@ public class OrderablePlaylistSongAdapter
     final OnMoveItemListener onMoveItemListener;
 
     public OrderablePlaylistSongAdapter(
-            @NonNull AppCompatActivity activity,
-            long playlistId, @NonNull ArrayList<Song> dataSet,
-            boolean usePalette, @Nullable CabHolder cabHolder,
-            @Nullable OnMoveItemListener onMoveItemListener)
+            @NonNull final AppCompatActivity activity,
+            final long playlistId, @NonNull final ArrayList<Song> dataSet,
+            final boolean usePalette, @Nullable final CabHolder cabHolder,
+            @Nullable final OnMoveItemListener onMoveItemListener)
     {
         super(activity, dataSet, usePalette, cabHolder);
         setMultiSelectMenuRes(R.menu.menu_playlists_songs_selection);
@@ -119,7 +118,7 @@ public class OrderablePlaylistSongAdapter
         void onMoveItem(int fromPosition, int toPosition);
     }
 
-    public class ViewHolder extends PlaylistSongAdapter.ViewHolder implements DraggableItemViewHolder {
+    public class ViewHolder extends PlaylistSongAdapter.ViewHolder {
         @DraggableItemStateFlags
         private int mDragStateFlags;
 

--- a/app/src/main/java/com/poupa/vinylmusicplayer/adapter/song/OrderablePlaylistSongAdapter.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/adapter/song/OrderablePlaylistSongAdapter.java
@@ -45,6 +45,17 @@ public class OrderablePlaylistSongAdapter
         this.onMoveItemListener = onMoveItemListener;
     }
 
+    @Override
+    public long getItemId(final int position) {
+        // Shifting by -1, since the very first item is the OFFSET_ITEM
+        final int adjustedPosition = position - 1;
+        if (adjustedPosition < 0) {return OFFSET_ITEM_ID;}
+
+        // Since the playlist may contain duplicates of same song,
+        // the song's ID cannot be used as the recycle view item ID
+        return ((IndexedSong)dataSet.get(adjustedPosition)).getUniqueId();
+    }
+
     @NonNull
     @Override
     protected SongAdapter.ViewHolder createViewHolder(@NonNull ItemListBinding binding) {

--- a/app/src/main/java/com/poupa/vinylmusicplayer/adapter/song/OrderablePlaylistSongAdapter.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/adapter/song/OrderablePlaylistSongAdapter.java
@@ -17,6 +17,7 @@ import com.poupa.vinylmusicplayer.databinding.ItemGridBinding;
 import com.poupa.vinylmusicplayer.databinding.ItemListBinding;
 import com.poupa.vinylmusicplayer.dialogs.RemoveFromPlaylistDialog;
 import com.poupa.vinylmusicplayer.interfaces.CabHolder;
+import com.poupa.vinylmusicplayer.misc.queue.IndexedSong;
 import com.poupa.vinylmusicplayer.model.Song;
 import com.poupa.vinylmusicplayer.util.ImageTheme.ThemeStyleUtil;
 import com.poupa.vinylmusicplayer.util.ViewUtil;

--- a/app/src/main/java/com/poupa/vinylmusicplayer/adapter/song/PlayingQueueAdapter.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/adapter/song/PlayingQueueAdapter.java
@@ -35,7 +35,7 @@ import com.poupa.vinylmusicplayer.model.Song;
 import com.poupa.vinylmusicplayer.util.PlayingSongDecorationUtil;
 import com.poupa.vinylmusicplayer.util.ViewUtil;
 
-import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author Karim Abou Zeid (kabouzeid)
@@ -53,7 +53,7 @@ public class PlayingQueueAdapter extends SongAdapter
 
     private int current;
 
-    public PlayingQueueAdapter(AppCompatActivity activity, ArrayList<Song> dataSet, int current, boolean usePalette, @Nullable CabHolder cabHolder) {
+    public PlayingQueueAdapter(AppCompatActivity activity, List<? extends Song> dataSet, int current, boolean usePalette, @Nullable CabHolder cabHolder) {
         super(activity, dataSet, R.layout.item_list, usePalette, cabHolder);
         this.showAlbumImage = false; // We don't want to load it in this adapter
         this.current = current;
@@ -101,7 +101,7 @@ public class PlayingQueueAdapter extends SongAdapter
         return CURRENT;
     }
 
-    public void swapDataSet(ArrayList<Song> dataSet, int position) {
+    public void swapDataSet(List<? extends Song> dataSet, int position) {
         this.dataSet = dataSet;
         current = position;
         notifyDataSetChanged();

--- a/app/src/main/java/com/poupa/vinylmusicplayer/adapter/song/ShuffleButtonSongAdapter.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/adapter/song/ShuffleButtonSongAdapter.java
@@ -17,14 +17,14 @@ import com.poupa.vinylmusicplayer.helper.MusicPlayerRemote;
 import com.poupa.vinylmusicplayer.interfaces.CabHolder;
 import com.poupa.vinylmusicplayer.model.Song;
 
-import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author Karim Abou Zeid (kabouzeid)
  */
 public class ShuffleButtonSongAdapter extends AbsOffsetSongAdapter {
 
-    public ShuffleButtonSongAdapter(AppCompatActivity activity, ArrayList<Song> dataSet, @LayoutRes int itemLayoutRes, boolean usePalette, @Nullable CabHolder cabHolder) {
+    public ShuffleButtonSongAdapter(AppCompatActivity activity, List<? extends Song> dataSet, @LayoutRes int itemLayoutRes, boolean usePalette, @Nullable CabHolder cabHolder) {
         super(activity, dataSet, itemLayoutRes, usePalette, cabHolder);
     }
 

--- a/app/src/main/java/com/poupa/vinylmusicplayer/adapter/song/SongAdapter.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/adapter/song/SongAdapter.java
@@ -21,12 +21,12 @@ import com.poupa.vinylmusicplayer.databinding.ItemGridBinding;
 import com.poupa.vinylmusicplayer.databinding.ItemListBinding;
 import com.poupa.vinylmusicplayer.databinding.ItemListSingleRowBinding;
 import com.poupa.vinylmusicplayer.helper.MusicPlayerRemote;
-import com.poupa.vinylmusicplayer.sort.SongSortOrder;
-import com.poupa.vinylmusicplayer.sort.SortOrder;
 import com.poupa.vinylmusicplayer.helper.menu.SongMenuHelper;
 import com.poupa.vinylmusicplayer.helper.menu.SongsMenuHelper;
 import com.poupa.vinylmusicplayer.interfaces.CabHolder;
 import com.poupa.vinylmusicplayer.model.Song;
+import com.poupa.vinylmusicplayer.sort.SongSortOrder;
+import com.poupa.vinylmusicplayer.sort.SortOrder;
 import com.poupa.vinylmusicplayer.util.ImageTheme.ThemeStyleUtil;
 import com.poupa.vinylmusicplayer.util.MusicUtil;
 import com.poupa.vinylmusicplayer.util.NavigationUtil;
@@ -35,6 +35,7 @@ import com.poupa.vinylmusicplayer.util.PreferenceUtil;
 import com.simplecityapps.recyclerview_fastscroll.views.FastScrollRecyclerView;
 
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author Karim Abou Zeid (kabouzeid)
@@ -45,7 +46,7 @@ public class SongAdapter
 {
 
     protected final AppCompatActivity activity;
-    protected ArrayList<Song> dataSet;
+    protected List<? extends Song> dataSet;
 
     protected final int itemLayoutRes;
 
@@ -55,12 +56,12 @@ public class SongAdapter
 
     public RecyclerView recyclerView;
 
-    public SongAdapter(AppCompatActivity activity, ArrayList<Song> dataSet, @LayoutRes int itemLayoutRes,
+    public SongAdapter(AppCompatActivity activity, List<? extends Song> dataSet, @LayoutRes int itemLayoutRes,
                        boolean usePalette, @Nullable CabHolder cabHolder) {
         this(activity, dataSet, itemLayoutRes, usePalette, cabHolder, true);
     }
 
-    public SongAdapter(AppCompatActivity activity, ArrayList<Song> dataSet, @LayoutRes int itemLayoutRes,
+    public SongAdapter(AppCompatActivity activity, List<? extends Song> dataSet, @LayoutRes int itemLayoutRes,
                        boolean usePalette, @Nullable CabHolder cabHolder, boolean showSectionName) {
         super(activity, cabHolder, R.menu.menu_media_selection);
         this.activity = activity;
@@ -77,7 +78,7 @@ public class SongAdapter
         recyclerView = rV;
     }
 
-    public void swapDataSet(ArrayList<Song> dataSet) {
+    public void swapDataSet(List<? extends Song> dataSet) {
         this.dataSet = dataSet;
         notifyDataSetChanged();
     }
@@ -95,7 +96,7 @@ public class SongAdapter
         return this.showAlbumImage;
     }
 
-    public ArrayList<Song> getDataSet() {
+    public List<? extends Song> getDataSet() {
         return dataSet;
     }
 

--- a/app/src/main/java/com/poupa/vinylmusicplayer/dialogs/AddToPlaylistDialog.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/dialogs/AddToPlaylistDialog.java
@@ -31,10 +31,10 @@ public class AddToPlaylistDialog extends DialogFragment {
     }
 
     @NonNull
-    public static AddToPlaylistDialog create(ArrayList<Song> songs) {
+    public static AddToPlaylistDialog create(List<? extends Song> songs) {
         AddToPlaylistDialog dialog = new AddToPlaylistDialog();
         Bundle args = new Bundle();
-        args.putParcelableArrayList(SONGS, songs);
+        args.putParcelableArrayList(SONGS, new ArrayList<>(songs));
         dialog.setArguments(args);
         return dialog;
     }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/dialogs/CreatePlaylistDialog.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/dialogs/CreatePlaylistDialog.java
@@ -16,6 +16,7 @@ import com.poupa.vinylmusicplayer.util.PlaylistsUtil;
 import com.poupa.vinylmusicplayer.util.SafeToast;
 
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author Karim Abou Zeid (kabouzeid), Aidan Follestad (afollestad)
@@ -37,10 +38,10 @@ public class CreatePlaylistDialog extends DialogFragment {
     }
 
     @NonNull
-    public static CreatePlaylistDialog create(ArrayList<Song> songs) {
+    public static CreatePlaylistDialog create(List<? extends Song> songs) {
         CreatePlaylistDialog dialog = new CreatePlaylistDialog();
         Bundle args = new Bundle();
-        args.putParcelableArrayList(SONGS, songs);
+        args.putParcelableArrayList(SONGS, new ArrayList<>(songs));
         dialog.setArguments(args);
         return dialog;
     }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/dialogs/ImportFromPlaylistDialog.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/dialogs/ImportFromPlaylistDialog.java
@@ -57,7 +57,7 @@ public class ImportFromPlaylistDialog extends DialogFragment {
                     .itemsCallback((materialDialog, view, i, charSequence) -> {
                         materialDialog.dismiss();
                         final Playlist sourcePlaylist = playlists.get(i).asPlaylist();
-                        final List<Song> songs = sourcePlaylist.getSongs(context);
+                        final List<? extends Song> songs = sourcePlaylist.getSongs(context);
                         if (songs.isEmpty()) {
                             SafeToast.show(context, R.string.playlist_is_empty);
                         } else {

--- a/app/src/main/java/com/poupa/vinylmusicplayer/dialogs/RemoveFromPlaylistDialog.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/dialogs/RemoveFromPlaylistDialog.java
@@ -30,7 +30,7 @@ public class RemoveFromPlaylistDialog extends DialogFragment {
     }
 
     @NonNull
-    public static RemoveFromPlaylistDialog create(long playlistId, ArrayList<Song> songs) {
+    public static RemoveFromPlaylistDialog create(long playlistId, ArrayList<? extends Song> songs) {
         RemoveFromPlaylistDialog dialog = new RemoveFromPlaylistDialog();
         Bundle args = new Bundle();
         args.putLong(PLAYLIST_ID, playlistId);

--- a/app/src/main/java/com/poupa/vinylmusicplayer/dialogs/helper/DeleteSongsDialogApi19.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/dialogs/helper/DeleteSongsDialogApi19.java
@@ -52,10 +52,10 @@ public class DeleteSongsDialogApi19 extends DialogFragment {
     }
 
     @NonNull
-    public static DeleteSongsDialogApi19 create(ArrayList<Song> songs) {
+    public static DeleteSongsDialogApi19 create(List<? extends Song> songs) {
         DeleteSongsDialogApi19 dialog = new DeleteSongsDialogApi19();
         Bundle args = new Bundle();
-        args.putParcelableArrayList(SONGS, songs);
+        args.putParcelableArrayList(SONGS, new ArrayList<>(songs));
         dialog.setArguments(args);
         return dialog;
     }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/dialogs/helper/DeleteSongsDialogApi30.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/dialogs/helper/DeleteSongsDialogApi30.java
@@ -54,10 +54,10 @@ public class DeleteSongsDialogApi30 extends Fragment {
     }
 
     @NonNull
-    public static DeleteSongsDialogApi30 create(ArrayList<Song> songs) {
+    public static DeleteSongsDialogApi30 create(List<? extends Song> songs) {
         DeleteSongsDialogApi30 dialog = new DeleteSongsDialogApi30();
         Bundle args = new Bundle();
-        args.putParcelableArrayList(SONGS, songs);
+        args.putParcelableArrayList(SONGS, new ArrayList<>(songs));
         dialog.setArguments(args);
         return dialog;
     }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/dialogs/helper/DeleteSongsHelper.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/dialogs/helper/DeleteSongsHelper.java
@@ -11,6 +11,7 @@ import com.poupa.vinylmusicplayer.helper.MusicPlayerRemote;
 import com.poupa.vinylmusicplayer.model.Song;
 
 import java.util.ArrayList;
+import java.util.List;
 
 public class DeleteSongsHelper {
 
@@ -22,7 +23,7 @@ public class DeleteSongsHelper {
         }
     }
 
-    public static void delete(ArrayList<Song> songs, @NonNull FragmentManager manager, @Nullable String tag) {
+    public static void delete(List<? extends Song> songs, @NonNull FragmentManager manager, @Nullable String tag) {
         if (Build.VERSION.SDK_INT < VERSION_CODES.R) {
             DeleteSongsDialogApi19.create(songs).show(manager, tag);
         } else {

--- a/app/src/main/java/com/poupa/vinylmusicplayer/helper/M3UWriter.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/helper/M3UWriter.java
@@ -16,7 +16,7 @@ import java.util.List;
 public class M3UWriter implements M3UConstants {
 
     public static void write(@NonNull final Context context, @NonNull final OutputStream stream, @NonNull final Playlist playlist) throws IOException {
-        List<Song> songs = playlist.getSongs(context);
+        List<? extends Song> songs = playlist.getSongs(context);
         if (!songs.isEmpty()) {
             stream.write(HEADER.getBytes(StandardCharsets.UTF_8));
 

--- a/app/src/main/java/com/poupa/vinylmusicplayer/helper/MusicPlayerRemote.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/helper/MusicPlayerRemote.java
@@ -448,7 +448,7 @@ public class MusicPlayerRemote {
     }
 
     public static IndexedSong getIndexedSongAt(int position) {
-        if (musicService != null && position >= 0 && position < getPlayingQueue().size()) {
+        if (musicService != null) {
             return musicService.getIndexedSongAt(position);
         }
         return IndexedSong.EMPTY_INDEXED_SONG;

--- a/app/src/main/java/com/poupa/vinylmusicplayer/helper/MusicPlayerRemote.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/helper/MusicPlayerRemote.java
@@ -186,7 +186,7 @@ public class MusicPlayerRemote {
     /**
      * Async
      */
-    public static void openQueue(final ArrayList<Song> queue, final int startPosition, final boolean startPlaying) {
+    public static void openQueue(final List<? extends Song> queue, final int startPosition, final boolean startPlaying) {
         if (!tryToHandleOpenPlayingQueue(queue, startPosition, startPlaying) && musicService != null) {
             if (!PreferenceUtil.getInstance().rememberShuffle()) {
                 setShuffleMode(MusicService.SHUFFLE_MODE_NONE);
@@ -198,7 +198,7 @@ public class MusicPlayerRemote {
     /**
      * Async
      */
-    public static void openAndShuffleQueue(final ArrayList<Song> queue, boolean startPlaying) {
+    public static void openAndShuffleQueue(final List<? extends Song> queue, boolean startPlaying) {
         if (!tryToHandleOpenPlayingQueue(queue, 0, startPlaying) && musicService != null) {
             musicService.openQueue(queue, MusicService.RANDOM_START_POSITION_ON_SHUFFLE, startPlaying, MusicService.SHUFFLE_MODE_SHUFFLE);
         }
@@ -208,7 +208,7 @@ public class MusicPlayerRemote {
         removeDuplicateBeforeQueuing(new ArrayList<>(Collections.singletonList(song)));
     }
 
-    private static void removeDuplicateBeforeQueuing (final ArrayList<Song> songsToAdd) {
+    private static void removeDuplicateBeforeQueuing (final List<? extends Song> songsToAdd) {
         // Deduplicate songs, favoring the occurrences in the new queue
         if (musicService == null) {return;}
         
@@ -237,7 +237,7 @@ public class MusicPlayerRemote {
         musicService.removeSongs(songsToRemove);
     }
 
-    public static void enqueueSongsWithConfirmation(final @NonNull Context context, final ArrayList<Song> queue, int positionInQueue) {
+    public static void enqueueSongsWithConfirmation(final @NonNull Context context, final List<? extends Song> queue, int positionInQueue) {
         if (musicService == null) {return;}
 
         if (tryToHandleOpenPlayingQueue(queue, positionInQueue, true)) {
@@ -289,7 +289,7 @@ public class MusicPlayerRemote {
 
     }
 
-    private static boolean tryToHandleOpenPlayingQueue(final ArrayList<Song> queue, final int startPosition, final boolean startPlaying) {
+    private static boolean tryToHandleOpenPlayingQueue(final List<? extends Song> queue, final int startPosition, final boolean startPlaying) {
         if (getPlayingQueue() == queue) {
             if (startPlaying) {playSongAt(startPosition, isPlaying());}
             else {setPosition(startPosition);}
@@ -393,7 +393,7 @@ public class MusicPlayerRemote {
         }
     }
 
-    public static void playNext(@NonNull ArrayList<Song> songs) {
+    public static void playNext(@NonNull List<? extends Song> songs) {
         if (musicService != null) {
             if (getPlayingQueue().size() > 0) {
                 removeDuplicateBeforeQueuing(songs);
@@ -422,7 +422,7 @@ public class MusicPlayerRemote {
         }
     }
 
-    public static void enqueue(@NonNull ArrayList<Song> songs) {
+    public static void enqueue(@NonNull List<? extends Song> songs) {
         if (musicService != null) {
             if (getPlayingQueue().size() > 0) {
                 removeDuplicateBeforeQueuing(songs);

--- a/app/src/main/java/com/poupa/vinylmusicplayer/helper/MusicPlayerRemote.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/helper/MusicPlayerRemote.java
@@ -381,7 +381,7 @@ public class MusicPlayerRemote {
 
     public static void playNext(Song song) {
         if (musicService != null) {
-            if (getPlayingQueue().size() > 0) {
+            if (!getPlayingQueue().isEmpty()) {
                 removeDuplicateBeforeQueuing(song);
                 musicService.addSongAfter(getPosition(), song);
             } else {
@@ -395,7 +395,7 @@ public class MusicPlayerRemote {
 
     public static void playNext(@NonNull List<? extends Song> songs) {
         if (musicService != null) {
-            if (getPlayingQueue().size() > 0) {
+            if (!getPlayingQueue().isEmpty()) {
                 removeDuplicateBeforeQueuing(songs);
                 musicService.addSongsAfter(getPosition(), songs);
             } else {
@@ -410,7 +410,7 @@ public class MusicPlayerRemote {
 
     public static void enqueue(Song song) {
         if (musicService != null) {
-            if (getPlayingQueue().size() > 0) {
+            if (!getPlayingQueue().isEmpty()) {
                 removeDuplicateBeforeQueuing(song);
                 musicService.addSong(song);
             } else {
@@ -424,7 +424,7 @@ public class MusicPlayerRemote {
 
     public static void enqueue(@NonNull List<? extends Song> songs) {
         if (musicService != null) {
-            if (getPlayingQueue().size() > 0) {
+            if (!getPlayingQueue().isEmpty()) {
                 removeDuplicateBeforeQueuing(songs);
                 musicService.addSongs(songs);
             } else {
@@ -455,7 +455,8 @@ public class MusicPlayerRemote {
     }
 
     public static void moveSong(int from, int to) {
-        if (musicService != null && from >= 0 && to >= 0 && from < getPlayingQueue().size() && to < getPlayingQueue().size()) {
+        final int size = getPlayingQueue().size();
+        if (musicService != null && from >= 0 && to >= 0 && from < size && to < size) {
             musicService.moveSong(from, to);
         }
     }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/helper/MusicPlayerRemote.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/helper/MusicPlayerRemote.java
@@ -205,7 +205,7 @@ public class MusicPlayerRemote {
     }
 
     private static void removeDuplicateBeforeQueuing (final Song song) {
-        removeDuplicateBeforeQueuing(new ArrayList<>(Collections.singletonList(song)));
+        removeDuplicateBeforeQueuing(Collections.singletonList(song));
     }
 
     private static void removeDuplicateBeforeQueuing (final List<? extends Song> songsToAdd) {
@@ -304,13 +304,6 @@ public class MusicPlayerRemote {
             return musicService.getCurrentSong();
         }
         return Song.EMPTY_SONG;
-    }
-
-    public static IndexedSong getCurrentIndexedSong() {
-        if (musicService != null) {
-            return musicService.getCurrentIndexedSong();
-        }
-        return IndexedSong.EMPTY_INDEXED_SONG;
     }
 
     public static int getPosition() {

--- a/app/src/main/java/com/poupa/vinylmusicplayer/helper/MusicPlayerRemote.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/helper/MusicPlayerRemote.java
@@ -212,12 +212,12 @@ public class MusicPlayerRemote {
         // Deduplicate songs, favoring the occurrences in the new queue
         if (musicService == null) {return;}
         
-        final ArrayList<Song> currentQueue = musicService.getPlayingQueue();
+        final List<? extends Song> currentQueue = musicService.getPlayingQueue();
         if (currentQueue.isEmpty()) {
             return;
         }
 
-        final List<Song> remainingSongsInQueue = currentQueue.subList(
+        final List<? extends Song> remainingSongsInQueue = currentQueue.subList(
                 musicService.getPosition() + 1,
                 currentQueue.size()
         );
@@ -245,7 +245,7 @@ public class MusicPlayerRemote {
             return;
         }
 
-        final ArrayList<Song> currentQueue = musicService.getPlayingQueue();
+        final List<? extends Song> currentQueue = musicService.getPlayingQueue();
         if (currentQueue.isEmpty()) {
             openQueue(queue, positionInQueue, true);
             return;
@@ -320,7 +320,7 @@ public class MusicPlayerRemote {
         return -1;
     }
 
-    public static ArrayList<Song> getPlayingQueue() {
+    public static List<? extends Song> getPlayingQueue() {
         if (musicService != null) {
             return musicService.getPlayingQueue();
         }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/helper/SearchQueryHelper.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/helper/SearchQueryHelper.java
@@ -10,9 +10,9 @@ import androidx.annotation.Nullable;
 import com.poupa.vinylmusicplayer.discog.Discography;
 import com.poupa.vinylmusicplayer.loader.GenreLoader;
 import com.poupa.vinylmusicplayer.loader.PlaylistSongLoader;
-import com.poupa.vinylmusicplayer.util.StringUtil;
 import com.poupa.vinylmusicplayer.loader.SongLoader;
 import com.poupa.vinylmusicplayer.model.Song;
+import com.poupa.vinylmusicplayer.util.StringUtil;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -65,7 +65,7 @@ public class SearchQueryHelper {
     }
 
     @NonNull
-    public static ArrayList<Song> getSongs(
+    public static List<? extends Song> getSongs(
             @Nullable final String focus,
             @NonNull final Bundle extras) {
         // First try known search metrics Genre and Playlist

--- a/app/src/main/java/com/poupa/vinylmusicplayer/helper/menu/SongsMenuHelper.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/helper/menu/SongsMenuHelper.java
@@ -15,7 +15,7 @@ import java.util.ArrayList;
  * @author Karim Abou Zeid (kabouzeid)
  */
 public class SongsMenuHelper {
-    public static void handleMenuClick(@NonNull FragmentActivity activity, @NonNull ArrayList<Song> songs, int menuItemId) {
+    public static void handleMenuClick(@NonNull FragmentActivity activity, @NonNull ArrayList<? extends Song> songs, int menuItemId) {
         if (menuItemId == R.id.action_play_next) {
             MusicPlayerRemote.playNext(songs);
         } else if (menuItemId == R.id.action_add_to_current_playing) {

--- a/app/src/main/java/com/poupa/vinylmusicplayer/loader/PlaylistSongLoader.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/loader/PlaylistSongLoader.java
@@ -14,6 +14,7 @@ import com.poupa.vinylmusicplayer.provider.StaticPlaylist;
 import com.poupa.vinylmusicplayer.util.StringUtil;
 
 import java.util.ArrayList;
+import java.util.List;
 
 public class PlaylistSongLoader {
     @NonNull
@@ -43,7 +44,7 @@ public class PlaylistSongLoader {
      * @return Song list from the playlist found by search term
      */
     @NonNull
-    public static ArrayList<Song> getPlaylistSongList(
+    public static List<? extends Song> getPlaylistSongList(
             @NonNull final String playlistNameSearchTerm)
     {
         // Find closest match

--- a/app/src/main/java/com/poupa/vinylmusicplayer/misc/queue/IndexedSong.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/misc/queue/IndexedSong.java
@@ -26,9 +26,9 @@ public class IndexedSong extends Song {
     public boolean isQuickEqual(@NonNull final Song song) {
         boolean ret = super.isQuickEqual(song);
 
-        if (getClass() == song.getClass()) {
-            IndexedSong indexedSong = (IndexedSong) song;
-            ret = ret && ((indexedSong.index == INVALID_INDEX) || (this.index == indexedSong.index));
+        if (ret && (getClass() == song.getClass())) {
+            final IndexedSong indexedSong = (IndexedSong) song;
+            ret = ((indexedSong.index == INVALID_INDEX) || (index == indexedSong.index));
         }
 
         return ret;

--- a/app/src/main/java/com/poupa/vinylmusicplayer/misc/queue/IndexedSong.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/misc/queue/IndexedSong.java
@@ -1,5 +1,7 @@
 package com.poupa.vinylmusicplayer.misc.queue;
 
+import androidx.annotation.NonNull;
+
 import com.poupa.vinylmusicplayer.model.Song;
 
 public class IndexedSong extends Song {
@@ -21,7 +23,7 @@ public class IndexedSong extends Song {
         this.uniqueId = uniqueId;
     }
 
-    public boolean isQuickEqual(Song song) {
+    public boolean isQuickEqual(@NonNull final Song song) {
         boolean ret = super.isQuickEqual(song);
 
         if (getClass() == song.getClass()) {

--- a/app/src/main/java/com/poupa/vinylmusicplayer/misc/queue/StaticPlayingQueue.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/misc/queue/StaticPlayingQueue.java
@@ -113,8 +113,8 @@ public class StaticPlayingQueue {
     /**
      * Add list of song at the end of both list
      */
-    public void addAll(@NonNull List<Song> songs) {
-        int position = size();
+    public void addAll(@NonNull final List<? extends Song> songs) {
+        final int position = size();
         for (Song song : songs) {
             add(song);
         }
@@ -181,7 +181,7 @@ public class StaticPlayingQueue {
     /**
      * Add songs after and including position, numbering need to be redone for every song after this position (+number of song)
      */
-    public void addAllAfter(int position, @NonNull List<Song> songs) {
+    public void addAllAfter(int position, @NonNull List<? extends Song> songs) {
         final int queueSize = queue.size();
         if (queueSize == 0) {
             addAll(songs);
@@ -320,7 +320,7 @@ public class StaticPlayingQueue {
 
     /* -------------------- queue getter info -------------------- */
 
-    public boolean openQueue(@Nullable final ArrayList<Song> playingQueue, final int startPosition, int shuffleMode) {
+    public boolean openQueue(@Nullable final List<? extends Song> playingQueue, final int startPosition, int shuffleMode) {
         if (playingQueue == null || playingQueue.isEmpty() || startPosition < 0 || startPosition >= playingQueue.size()) {
             return false;
         }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/misc/queue/StaticPlayingQueue.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/misc/queue/StaticPlayingQueue.java
@@ -26,10 +26,6 @@ public class StaticPlayingQueue {
 
     private int nextPosition;
 
-    /** Used to know when songs and queue.song are not equal so that getPlayingQueueSongOnly() will not always recreate songs every time */
-    private boolean songsIsStale;
-    /** Necessary as all implementation use MusicPlayerRemove.getPlayingQueue and want a pointer that doesn't change to a list of song */
-    private final ArrayList<Song> songs;
     /** List of element currently saved (way better than songs to ensure only the correct occurrence of a song is modified) */
     private ArrayList<IndexedSong> queue;
     /** Copy of the queue used to allow revert of history last operation */
@@ -38,12 +34,10 @@ public class StaticPlayingQueue {
     private long nextUniqueId;
 
     public StaticPlayingQueue() {
-        songs = new ArrayList<>();
         queue = new ArrayList<>();
         originalQueue = new ArrayList<>();
         shuffleMode = SHUFFLE_MODE_NONE;
         currentPosition = INVALID_POSITION;
-        songsIsStale = false;
 
         restoreUniqueId();
     }
@@ -63,10 +57,6 @@ public class StaticPlayingQueue {
                 remove(i);
             }
         }
-
-        songs = new ArrayList<>();
-        songsIsStale = true;
-        resetSongs();
 
         restoreUniqueId();
     }
@@ -106,8 +96,6 @@ public class StaticPlayingQueue {
         long uniqueId = getNextUniqueId();
         queue.add(new IndexedSong(song, queue.size(), uniqueId));
         originalQueue.add(new IndexedSong(song, originalQueue.size(), uniqueId));
-
-        songsIsStale = true;
     }
 
     /**
@@ -143,8 +131,6 @@ public class StaticPlayingQueue {
         queue.add(position, new IndexedSong(song, previousPosition, uniqueId));
 
         updateQueueIndexesAfterSongsModification(position, 0, previousPosition, +1);
-
-        songsIsStale = true;
     }
 
     /**
@@ -210,8 +196,6 @@ public class StaticPlayingQueue {
         if (getShuffleMode() == SHUFFLE_MODE_SHUFFLE) {
             ShuffleHelper.makeShuffleList(queue.subList(position, position + songs.size()), 0);
         }
-
-        songsIsStale = true;
     }
 
     /**
@@ -241,8 +225,6 @@ public class StaticPlayingQueue {
         } else if (from == currentPosition) {
             this.currentPosition = to;
         }
-
-        songsIsStale = true;
     }
 
     private int rePosition(int deletedPosition) {
@@ -270,8 +252,6 @@ public class StaticPlayingQueue {
 
         updateQueueIndexesAfterSongsModification(-1, 0, o.index, -1);
 
-        songsIsStale = true;
-
         return rePosition(position);
     }
 
@@ -286,8 +266,6 @@ public class StaticPlayingQueue {
                 }
             }
         }
-
-        songsIsStale = true;
 
         return hasPositionChanged;
     }
@@ -306,7 +284,6 @@ public class StaticPlayingQueue {
     }
 
     public void clear() {
-        songs.clear();
         queue.clear();
         originalQueue.clear();
 
@@ -315,7 +292,6 @@ public class StaticPlayingQueue {
 
     private void revert() {
         queue = new ArrayList<>(originalQueue);
-        songsIsStale = true;
     }
 
     /* -------------------- queue getter info -------------------- */
@@ -341,18 +317,6 @@ public class StaticPlayingQueue {
 
     public ArrayList<IndexedSong> getOriginalPlayingQueue() {
         return originalQueue;
-    }
-
-    private void resetSongs() {
-        this.songs.clear();
-        songs.addAll(queue);
-        songsIsStale = false;
-    }
-
-    public ArrayList<Song> getPlayingQueueSongOnly() {
-        if (songsIsStale)
-            resetSongs();
-        return songs;
     }
 
     public int size() {
@@ -463,7 +427,6 @@ public class StaticPlayingQueue {
                 break;
             case SHUFFLE_MODE_SHUFFLE:
                 ShuffleHelper.makeShuffleList(queue, currentPosition);
-                songsIsStale = true;
                 currentPosition = 0;
                 break;
         }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/model/Playlist.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/model/Playlist.java
@@ -11,7 +11,7 @@ import com.poupa.vinylmusicplayer.util.MusicUtil;
 
 import org.jetbrains.annotations.NonNls;
 
-import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -67,7 +67,7 @@ public class Playlist implements Parcelable {
     }
 
     @NonNull
-    public ArrayList<Song> getSongs(Context context) {
+    public List<? extends Song> getSongs(Context context) {
         // this default implementation covers static playlists
         StaticPlaylist staticPlaylist = new StaticPlaylist(name);
         return staticPlaylist.asSongs();

--- a/app/src/main/java/com/poupa/vinylmusicplayer/model/Song.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/model/Song.java
@@ -81,7 +81,7 @@ public class Song implements Parcelable {
         year = song.year;
     }
 
-    public boolean isQuickEqual(Song song) {
+    public boolean isQuickEqual(@NonNull final Song song) {
         return (id == song.id);
     }
 

--- a/app/src/main/java/com/poupa/vinylmusicplayer/model/smartplaylist/HistoryPlaylist.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/model/smartplaylist/HistoryPlaylist.java
@@ -60,7 +60,7 @@ public class HistoryPlaylist extends AbsSmartPlaylist {
 
     @Override
     public void importPlaylist(@NonNull Context context, @NonNull Playlist playlist) {
-        List<Song> songs = playlist.getSongs(context);
+        List<? extends Song> songs = playlist.getSongs(context);
         List<Long> songIds = new ArrayList<>(songs.size());
         for (Song song : songs) {songIds.add(song.id);}
 

--- a/app/src/main/java/com/poupa/vinylmusicplayer/provider/SongList.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/provider/SongList.java
@@ -8,6 +8,7 @@ import androidx.annotation.Nullable;
 
 import com.poupa.vinylmusicplayer.App;
 import com.poupa.vinylmusicplayer.discog.Discography;
+import com.poupa.vinylmusicplayer.misc.queue.IndexedSong;
 import com.poupa.vinylmusicplayer.model.Song;
 import com.poupa.vinylmusicplayer.util.StringUtil;
 
@@ -174,5 +175,32 @@ class PreferencesBackedSongList extends MutableSongList {
             name = newName;
         }
         preferences.edit().putString(PREF_NAME_PREFIX + name, values.toString()).apply();
+    }
+}
+
+class PreferenceBackedReorderableSongList extends PreferencesBackedSongList {
+    public PreferenceBackedReorderableSongList(@NonNull final String name) {
+        super(name);
+    }
+
+    // Assign a stable and unique ID to each song in the list. That ID can then be used as UI RecycleView's ID
+    // - to be unique: the Song's id cannot be used since the list can contain duplicate of same some
+    // - to be stable: the postition of the song in the list cannot be used as an ID since the song can be moved (hence the position changes)
+
+    private long nextUniqueId = 0L;
+
+    @Override
+    @NonNull
+    public List<? extends Song> asSongs() {
+        final List<? extends Song> songs = super.asSongs();
+        final int count = songs.size();
+
+        final ArrayList<IndexedSong> indexedSongs = new ArrayList<>(count);
+        for (int i=0; i<count; ++i) {
+            ++nextUniqueId;
+            indexedSongs.add(new IndexedSong(songs.get(i), i, nextUniqueId));
+        }
+
+        return indexedSongs;
     }
 }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/provider/SongList.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/provider/SongList.java
@@ -42,7 +42,7 @@ abstract class SongList {
     }
 
     @NonNull
-    public ArrayList<Song> asSongs() {
+    public List<? extends Song> asSongs() {
         ArrayList<Song> result = new ArrayList<>();
         ArrayList<Long> orphanIds = new ArrayList<>();
 

--- a/app/src/main/java/com/poupa/vinylmusicplayer/provider/SongList.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/provider/SongList.java
@@ -49,7 +49,7 @@ abstract class SongList {
         // Since the song list is decoupled from Discography, we need to check its content
         // against the valid songs in discog
         final Map<Long, Song> availableSongsById = Discography.getInstance().getAllSongsById();
-        for (Long id : songIds) {
+        for (final Long id : songIds) {
             final Song matchingSong = availableSongsById.get(id);
             if (matchingSong != null) {
                 result.add(matchingSong);
@@ -112,11 +112,11 @@ abstract class MutableSongList extends SongList {
 }
 
 class PreferencesBackedSongList extends MutableSongList {
-    private final static String SEPARATOR = ",";
-    private final static String PREF_NAME_PREFIX = "SONG_IDS_";
+    private static final String SEPARATOR = ",";
+    private static final String PREF_NAME_PREFIX = "SONG_IDS_";
 
     private static SharedPreferences preferences = null;
-    protected static SharedPreferences getPreferences() {
+    static SharedPreferences getPreferences() {
         if (preferences == null) {
             preferences = PreferenceManager.getDefaultSharedPreferences(App.getStaticContext());
         }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/provider/StaticPlaylist.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/provider/StaticPlaylist.java
@@ -12,7 +12,9 @@ import com.poupa.vinylmusicplayer.App;
 import com.poupa.vinylmusicplayer.R;
 import com.poupa.vinylmusicplayer.loader.PlaylistLoader;
 import com.poupa.vinylmusicplayer.loader.PlaylistSongLoader;
+import com.poupa.vinylmusicplayer.misc.queue.IndexedSong;
 import com.poupa.vinylmusicplayer.model.Playlist;
+import com.poupa.vinylmusicplayer.model.Song;
 import com.poupa.vinylmusicplayer.util.SafeToast;
 
 import java.util.ArrayList;
@@ -25,7 +27,10 @@ import java.util.UUID;
  * @author SC (soncaokim)
  */
 public class StaticPlaylist extends PreferencesBackedSongList {
-    static final String PREF_MIGRATED_STATIC_PLAYLISTS = "migrated_static_playlists";
+    private static final String PREF_MIGRATED_STATIC_PLAYLISTS = "migrated_static_playlists";
+
+    // A playlist can contain duplicate of same song -> assign an unique Id to each song
+    private long nextUniqueId = 0L;
 
     @NonNull
     private static List<StaticPlaylist> importDevicePlaylists(@NonNull final Context context, @NonNull final Set<String> internalNames) {
@@ -132,6 +137,21 @@ public class StaticPlaylist extends PreferencesBackedSongList {
 
     public StaticPlaylist(@NonNull String name) {
         super(name);
+    }
+
+    @Override
+    @NonNull
+    public List<? extends Song> asSongs() {
+        final List<? extends Song> songs = super.asSongs();
+        final int count = songs.size();
+
+        final ArrayList<IndexedSong> indexedSongs = new ArrayList<>(count);
+        for (int i=0; i<count; ++i) {
+            ++nextUniqueId;
+            indexedSongs.add(new IndexedSong(songs.get(i), i, nextUniqueId));
+        }
+
+        return indexedSongs;
     }
 
     public Playlist asPlaylist() {

--- a/app/src/main/java/com/poupa/vinylmusicplayer/provider/StaticPlaylist.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/provider/StaticPlaylist.java
@@ -12,9 +12,7 @@ import com.poupa.vinylmusicplayer.App;
 import com.poupa.vinylmusicplayer.R;
 import com.poupa.vinylmusicplayer.loader.PlaylistLoader;
 import com.poupa.vinylmusicplayer.loader.PlaylistSongLoader;
-import com.poupa.vinylmusicplayer.misc.queue.IndexedSong;
 import com.poupa.vinylmusicplayer.model.Playlist;
-import com.poupa.vinylmusicplayer.model.Song;
 import com.poupa.vinylmusicplayer.util.SafeToast;
 
 import java.util.ArrayList;
@@ -26,11 +24,8 @@ import java.util.UUID;
 /**
  * @author SC (soncaokim)
  */
-public class StaticPlaylist extends PreferencesBackedSongList {
+public class StaticPlaylist extends PreferenceBackedReorderableSongList {
     private static final String PREF_MIGRATED_STATIC_PLAYLISTS = "migrated_static_playlists";
-
-    // A playlist can contain duplicate of same song -> assign an unique Id to each song
-    private long nextUniqueId = 0L;
 
     @NonNull
     private static List<StaticPlaylist> importDevicePlaylists(@NonNull final Context context, @NonNull final Set<String> internalNames) {
@@ -138,21 +133,6 @@ public class StaticPlaylist extends PreferencesBackedSongList {
 
     public StaticPlaylist(@NonNull final String name) {
         super(name);
-    }
-
-    @Override
-    @NonNull
-    public List<? extends Song> asSongs() {
-        final List<? extends Song> songs = super.asSongs();
-        final int count = songs.size();
-
-        final ArrayList<IndexedSong> indexedSongs = new ArrayList<>(count);
-        for (int i=0; i<count; ++i) {
-            ++nextUniqueId;
-            indexedSongs.add(new IndexedSong(songs.get(i), i, nextUniqueId));
-        }
-
-        return indexedSongs;
     }
 
     public Playlist asPlaylist() {

--- a/app/src/main/java/com/poupa/vinylmusicplayer/provider/StaticPlaylist.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/provider/StaticPlaylist.java
@@ -103,7 +103,7 @@ public class StaticPlaylist extends PreferencesBackedSongList {
     }
 
     @Nullable
-    public static StaticPlaylist getPlaylist(long id) {
+    public static StaticPlaylist getPlaylist(final long id) {
         List<StaticPlaylist> all = getAllPlaylists();
         for (StaticPlaylist item : all) {
             Playlist playlist = item.asPlaylist();
@@ -113,7 +113,7 @@ public class StaticPlaylist extends PreferencesBackedSongList {
     }
 
     @Nullable
-    public static StaticPlaylist getPlaylist(@NonNull String playlistName) {
+    public static StaticPlaylist getPlaylist(@NonNull final String playlistName) {
         List<StaticPlaylist> all = getAllPlaylists();
         for (StaticPlaylist item : all) {
             Playlist playlist = item.asPlaylist();
@@ -122,7 +122,8 @@ public class StaticPlaylist extends PreferencesBackedSongList {
         return null;
     }
 
-    public static StaticPlaylist getOrCreatePlaylist(@NonNull String name) {
+    @NonNull
+    public static StaticPlaylist getOrCreatePlaylist(@NonNull final String name) {
         StaticPlaylist result = getPlaylist(name);
         if (result == null) {
             result = new StaticPlaylist(name);
@@ -131,11 +132,11 @@ public class StaticPlaylist extends PreferencesBackedSongList {
         return result;
     }
 
-    public static void removePlaylist(@NonNull String name) {
+    public static void removePlaylist(@NonNull final String name) {
         remove(name);
     }
 
-    public StaticPlaylist(@NonNull String name) {
+    public StaticPlaylist(@NonNull final String name) {
         super(name);
     }
 

--- a/app/src/main/java/com/poupa/vinylmusicplayer/service/BrowsableMusicProvider.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/service/BrowsableMusicProvider.java
@@ -306,7 +306,7 @@ public class BrowsableMusicProvider {
 
     @NonNull
     private List<MediaBrowserCompat.MediaItem> getSpecificPlaylistChildren(@NonNull Resources resources, @NonNull String path) {
-        List<Song> songs = null;
+        List<? extends Song> songs = null;
         String[] pathParts = null;
         switch (path) {
             case BrowsableMediaIDHelper.MEDIA_ID_MUSICS_BY_LAST_ADDED:
@@ -357,7 +357,7 @@ public class BrowsableMusicProvider {
 
     private <T> void buildMediaItemsFromList(
             @NonNull List<MediaBrowserCompat.MediaItem> destination,
-            @Nullable List<T> source,
+            @Nullable List<? extends T> source,
             int startPosition,
             String[] pathParts,
             Function<T, Long> pathIdExtractor,
@@ -370,7 +370,7 @@ public class BrowsableMusicProvider {
     ) {
         if (source == null) {return;}
 
-        final List<T> truncatedSource = truncatedList(source, startPosition);
+        final List<? extends T> truncatedSource = truncatedList(source, startPosition);
         for (T item : truncatedSource) {
             BrowsableMediaItem.Builder builder = BrowsableMediaItem.with(mContext)
                     .path(pathParts, pathIdExtractor.apply(item))
@@ -395,7 +395,7 @@ public class BrowsableMusicProvider {
     }
 
     @NonNull
-    private static <T> List<T> truncatedList(@NonNull List<T> songs, int startPosition) {
+    private static <T> List<? extends T> truncatedList(@NonNull List<T> songs, int startPosition) {
         // As per https://developer.android.com/training/cars/media
         // Android Auto and Android Automotive OS have strict limits on how many media items they can display in each level of the menu
         final int LISTING_SIZE_LIMIT = 50;

--- a/app/src/main/java/com/poupa/vinylmusicplayer/service/MusicService.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/service/MusicService.java
@@ -508,7 +508,7 @@ public class MusicService extends MediaBrowserServiceCompat implements SharedPre
                 return false;
             }
 
-            return getCurrentIndexedSong().isQuickEqual(song);
+            return getCurrentSong().isQuickEqual(song);
         }
     }
 
@@ -749,11 +749,7 @@ public class MusicService extends MediaBrowserServiceCompat implements SharedPre
     }
 
     public Song getCurrentSong() {
-        return getCurrentIndexedSong();
-    }
-
-    public IndexedSong getCurrentIndexedSong() {
-        return getIndexedSongAt(getPosition());
+        return getSongAt(getPosition());
     }
 
     private Song getSongAt(int position) {

--- a/app/src/main/java/com/poupa/vinylmusicplayer/service/MusicService.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/service/MusicService.java
@@ -778,7 +778,7 @@ public class MusicService extends MediaBrowserServiceCompat implements SharedPre
 
     public List<? extends Song> getPlayingQueue() {
         synchronized (this) {
-            return playingQueue.getPlayingQueueSongOnly();
+            return playingQueue.getPlayingQueue();
         }
     }
 

--- a/app/src/main/java/com/poupa/vinylmusicplayer/service/MusicService.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/service/MusicService.java
@@ -343,6 +343,8 @@ public class MusicService extends MediaBrowserServiceCompat implements SharedPre
 
     @Override
     public void onDestroy() {
+        super.onDestroy();
+
         unregisterReceiver(widgetIntentReceiver);
         unregisterReceiver(updateFavoriteReceiver);
 

--- a/app/src/main/java/com/poupa/vinylmusicplayer/service/MusicService.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/service/MusicService.java
@@ -299,7 +299,7 @@ public class MusicService extends MediaBrowserServiceCompat implements SharedPre
                     case ACTION_PLAY_PLAYLIST:
                         Playlist playlist = intent.getParcelableExtra(INTENT_EXTRA_PLAYLIST);
                         if (playlist != null) {
-                            ArrayList<Song> playlistSongs = playlist.getSongs(this);
+                            List<? extends Song> playlistSongs = playlist.getSongs(this);
                             if (!playlistSongs.isEmpty()) {
                                 synchronized (this) {
                                     int shuffleMode = intent.getIntExtra(INTENT_EXTRA_SHUFFLE_MODE, playingQueue.getShuffleMode());
@@ -837,7 +837,7 @@ public class MusicService extends MediaBrowserServiceCompat implements SharedPre
         propagateShuffleChange();
     }
 
-    public void openQueue(@Nullable final ArrayList<Song> queue, final int startPosition, final boolean startPlaying, final int shuffleMode) {
+    public void openQueue(@Nullable final List<? extends Song> queue, final int startPosition, final boolean startPlaying, final int shuffleMode) {
         int position;
         if (queue != null && shuffleMode != SHUFFLE_MODE_NONE && startPosition == RANDOM_START_POSITION_ON_SHUFFLE) {
             position = new Random().nextInt(queue.size());
@@ -857,7 +857,7 @@ public class MusicService extends MediaBrowserServiceCompat implements SharedPre
         }
     }
 
-    public void openQueue(@Nullable final ArrayList<Song> queue, final int startPosition, final boolean startPlaying) {
+    public void openQueue(@Nullable final List<? extends Song> queue, final int startPosition, final boolean startPlaying) {
         synchronized (this) {
             openQueue(queue, startPosition, startPlaying, playingQueue.getShuffleMode());
         }
@@ -877,7 +877,7 @@ public class MusicService extends MediaBrowserServiceCompat implements SharedPre
         notifyChange(QUEUE_CHANGED);
     }
 
-    public void addSongsAfter(int position, List<Song> songs) {
+    public void addSongsAfter(int position, List<? extends Song> songs) {
         synchronized (this) {
             playingQueue.addAllAfter(position, songs);
         }
@@ -891,7 +891,7 @@ public class MusicService extends MediaBrowserServiceCompat implements SharedPre
         notifyChange(QUEUE_CHANGED);
     }
 
-    public void addSongs(List<Song> songs) {
+    public void addSongs(List<? extends Song> songs) {
         synchronized (this) {
             playingQueue.addAll(songs);
             notifyChange(QUEUE_CHANGED);

--- a/app/src/main/java/com/poupa/vinylmusicplayer/service/MusicService.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/service/MusicService.java
@@ -776,7 +776,7 @@ public class MusicService extends MediaBrowserServiceCompat implements SharedPre
         }
     }
 
-    public ArrayList<Song> getPlayingQueue() {
+    public List<? extends Song> getPlayingQueue() {
         synchronized (this) {
             return playingQueue.getPlayingQueueSongOnly();
         }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/AlbumDetailActivity.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/AlbumDetailActivity.java
@@ -54,7 +54,7 @@ import com.poupa.vinylmusicplayer.util.NavigationUtil;
 import com.poupa.vinylmusicplayer.util.PreferenceUtil;
 import com.poupa.vinylmusicplayer.util.SafeToast;
 
-import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
 
 import retrofit2.Call;
@@ -274,7 +274,7 @@ public class AlbumDetailActivity
     @Override
     public boolean onOptionsItemSelected(@NonNull final MenuItem item) {
         final int id = item.getItemId();
-        final ArrayList<Song> songs = adapter.getDataSet();
+        final List<? extends Song> songs = adapter.getDataSet();
         if (id == R.id.action_sleep_timer) {
             new SleepTimerDialog().show(getSupportFragmentManager(), "SET_SLEEP_TIMER");
             return true;

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/GenreDetailActivity.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/GenreDetailActivity.java
@@ -37,6 +37,7 @@ import com.poupa.vinylmusicplayer.util.ViewUtil;
 import com.simplecityapps.recyclerview_fastscroll.views.FastScrollRecyclerView;
 
 import java.util.ArrayList;
+import java.util.List;
 
 public class GenreDetailActivity extends AbsSlidingMusicPanelActivity implements CabHolder, LoaderManager.LoaderCallbacks<ArrayList<Song>> {
 
@@ -116,7 +117,7 @@ public class GenreDetailActivity extends AbsSlidingMusicPanelActivity implements
     @Override
     public boolean onOptionsItemSelected(@NonNull MenuItem item) {
         final int id = item.getItemId();
-        final ArrayList<Song> songs = adapter.getDataSet();
+        final List<? extends Song> songs = adapter.getDataSet();
         if (id == R.id.action_add_to_current_playing) {
             MusicPlayerRemote.enqueue(songs);
             return true;

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/MainActivity.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/MainActivity.java
@@ -49,7 +49,7 @@ import com.poupa.vinylmusicplayer.util.PreferenceUtil;
 import com.sothree.slidinguppanel.SlidingUpPanelLayout;
 
 import java.io.File;
-import java.util.ArrayList;
+import java.util.List;
 
 public class MainActivity extends AbsSlidingMusicPanelActivity {
 
@@ -285,7 +285,7 @@ public class MainActivity extends AbsSlidingMusicPanelActivity {
 
         if (intent.getAction() != null && intent.getAction().equals(MediaStore.INTENT_ACTION_MEDIA_PLAY_FROM_SEARCH)) {
             final String focus = intent.getStringExtra(MediaStore.EXTRA_MEDIA_FOCUS);
-            final ArrayList<Song> songs =
+            final List<? extends Song> songs =
                     SearchQueryHelper.getSongs(focus, intent.getExtras());
             // Guards against no songs found. Will cause a crash otherwise
             if (songs.size() > 0) {

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/PlaylistDetailActivity.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/PlaylistDetailActivity.java
@@ -48,12 +48,13 @@ import com.poupa.vinylmusicplayer.util.PreferenceUtil;
 import com.poupa.vinylmusicplayer.util.ViewUtil;
 
 import java.util.ArrayList;
+import java.util.List;
 
 public class PlaylistDetailActivity
         extends AbsSlidingMusicPanelActivity
         implements
             CabHolder,
-            LoaderManager.LoaderCallbacks<ArrayList<Song>>
+            LoaderManager.LoaderCallbacks<List<? extends Song>>
 {
 
     private static final int LOADER_ID = LoaderIds.PLAYLIST_DETAIL_ACTIVITY;
@@ -121,8 +122,9 @@ public class PlaylistDetailActivity
                     this,
                     (fromPosition, toPosition) -> {
                         if (PlaylistsUtil.moveItem(playlist.id, fromPosition, toPosition)) {
-                            Song song = adapter.getDataSet().remove(fromPosition);
-                            adapter.getDataSet().add(toPosition, song);
+                            final List<Song> dataSet = (List<Song>)adapter.getDataSet();
+                            final Song song = dataSet.remove(fromPosition);
+                            dataSet.add(toPosition, song);
                             adapter.notifyItemMoved(fromPosition, toPosition);
                         }
                     });
@@ -282,19 +284,19 @@ public class PlaylistDetailActivity
 
     @Override
     @NonNull
-    public Loader<ArrayList<Song>> onCreateLoader(int id, final Bundle args) {
+    public Loader<List<? extends Song>> onCreateLoader(int id, final Bundle args) {
         return new AsyncPlaylistSongLoader(this, playlist);
     }
 
     @Override
-    public void onLoadFinished(@NonNull final Loader<ArrayList<Song>> loader, final ArrayList<Song> data) {
+    public void onLoadFinished(@NonNull final Loader<List<? extends Song>> loader, final List<? extends Song> data) {
         if (adapter != null) {
             adapter.swapDataSet(data);
         }
     }
 
     @Override
-    public void onLoaderReset(@NonNull final Loader<ArrayList<Song>> loader) {
+    public void onLoaderReset(@NonNull final Loader<List<? extends Song>> loader) {
         if (adapter != null) {
             adapter.swapDataSet(new ArrayList<>());
         }
@@ -305,7 +307,7 @@ public class PlaylistDetailActivity
         LoaderManager.getInstance(this).restartLoader(LOADER_ID, null, this);
     }
 
-    private static class AsyncPlaylistSongLoader extends WrappedAsyncTaskLoader<ArrayList<Song>> {
+    private static class AsyncPlaylistSongLoader extends WrappedAsyncTaskLoader<List<? extends Song>> {
         private final Playlist playlist;
 
         AsyncPlaylistSongLoader(final Context context, final Playlist playlist) {
@@ -315,7 +317,7 @@ public class PlaylistDetailActivity
 
         @NonNull
         @Override
-        public ArrayList<Song> loadInBackground() {
+        public List<? extends Song> loadInBackground() {
             return playlist.getSongs(getContext());
         }
     }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/fragments/mainactivity/library/pager/SongsFragment.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/fragments/mainactivity/library/pager/SongsFragment.java
@@ -18,6 +18,7 @@ import com.poupa.vinylmusicplayer.model.Song;
 import com.poupa.vinylmusicplayer.util.PreferenceUtil;
 
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author Karim Abou Zeid (kabouzeid)
@@ -44,7 +45,7 @@ public class SongsFragment extends AbsLibraryPagerRecyclerViewCustomGridSizeFrag
         int itemLayoutRes = getItemLayoutRes();
         notifyLayoutResChanged(itemLayoutRes);
         boolean usePalette = loadUsePalette();
-        ArrayList<Song> dataSet = getAdapter() == null ? new ArrayList<>() : getAdapter().getDataSet();
+        List<? extends Song> dataSet = getAdapter() == null ? new ArrayList<>() : getAdapter().getDataSet();
 
         if (getGridSize() <= getMaxGridSizeForList()) {
             return new ShuffleButtonSongAdapter(

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/fragments/player/card/CardPlayerFragment.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/fragments/player/card/CardPlayerFragment.java
@@ -31,7 +31,6 @@ import com.poupa.vinylmusicplayer.databinding.ItemListBinding;
 import com.poupa.vinylmusicplayer.dialogs.SongShareDialog;
 import com.poupa.vinylmusicplayer.helper.MusicPlayerRemote;
 import com.poupa.vinylmusicplayer.helper.menu.SongMenuHelper;
-import com.poupa.vinylmusicplayer.misc.queue.IndexedSong;
 import com.poupa.vinylmusicplayer.model.Song;
 import com.poupa.vinylmusicplayer.ui.activities.base.AbsSlidingMusicPanelActivity;
 import com.poupa.vinylmusicplayer.ui.fragments.player.AbsPlayerFragment;
@@ -182,7 +181,7 @@ public class CardPlayerFragment extends AbsPlayerFragment implements SlidingUpPa
     }
 
     private void updateCurrentSong() {
-        impl.updateCurrentSong(MusicPlayerRemote.getCurrentIndexedSong());
+        impl.updateCurrentSong(MusicPlayerRemote.getCurrentSong());
 
         // give the adapter a chance to update the decoration
         recyclerView.getAdapter().notifyItemChanged(MusicPlayerRemote.getPosition());
@@ -286,7 +285,7 @@ public class CardPlayerFragment extends AbsPlayerFragment implements SlidingUpPa
     interface Impl {
         void init();
 
-        void updateCurrentSong(IndexedSong song);
+        void updateCurrentSong(@NonNull final Song song);
 
         void animateColorChange(final int newColor);
 
@@ -406,7 +405,7 @@ public class CardPlayerFragment extends AbsPlayerFragment implements SlidingUpPa
         }
 
         @Override
-        public void updateCurrentSong(IndexedSong song) {
+        public void updateCurrentSong(@NonNull final Song song) {
             currentSong = song;
             currentSongViewHolder.title.setText(song.title);
             currentSongViewHolder.text.setText(MusicUtil.getSongInfoString(song));
@@ -449,7 +448,7 @@ public class CardPlayerFragment extends AbsPlayerFragment implements SlidingUpPa
         }
 
         @Override
-        public void updateCurrentSong(IndexedSong song) {
+        public void updateCurrentSong(@NonNull final Song song) {
             fragment.toolbar.setTitle(song.title);
             fragment.toolbar.setSubtitle(MusicUtil.getSongInfoString(song));
         }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/fragments/player/flat/FlatPlayerFragment.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/fragments/player/flat/FlatPlayerFragment.java
@@ -28,7 +28,6 @@ import com.poupa.vinylmusicplayer.databinding.ItemListBinding;
 import com.poupa.vinylmusicplayer.dialogs.SongShareDialog;
 import com.poupa.vinylmusicplayer.helper.MusicPlayerRemote;
 import com.poupa.vinylmusicplayer.helper.menu.SongMenuHelper;
-import com.poupa.vinylmusicplayer.misc.queue.IndexedSong;
 import com.poupa.vinylmusicplayer.model.Song;
 import com.poupa.vinylmusicplayer.ui.activities.base.AbsSlidingMusicPanelActivity;
 import com.poupa.vinylmusicplayer.ui.fragments.player.AbsPlayerFragment;
@@ -177,7 +176,7 @@ public class FlatPlayerFragment extends AbsPlayerFragment implements SlidingUpPa
 
     @SuppressWarnings("ConstantConditions")
     private void updateCurrentSong() {
-        impl.updateCurrentSong(MusicPlayerRemote.getCurrentIndexedSong());
+        impl.updateCurrentSong(MusicPlayerRemote.getCurrentSong());
 
         // give the adapter a chance to update the decoration
         recyclerView.getAdapter().notifyItemChanged(MusicPlayerRemote.getPosition());
@@ -267,7 +266,7 @@ public class FlatPlayerFragment extends AbsPlayerFragment implements SlidingUpPa
     interface Impl {
         void init();
 
-        void updateCurrentSong(IndexedSong song);
+        void updateCurrentSong(@NonNull final Song song);
 
         void animateColorChange(final int newColor);
 
@@ -375,7 +374,7 @@ public class FlatPlayerFragment extends AbsPlayerFragment implements SlidingUpPa
         }
 
         @Override
-        public void updateCurrentSong(IndexedSong song) {
+        public void updateCurrentSong(@NonNull final Song song) {
             currentSong = song;
             currentSongViewHolder.title.setText(song.title);
             currentSongViewHolder.text.setText(MusicUtil.getSongInfoString(song));
@@ -412,7 +411,7 @@ public class FlatPlayerFragment extends AbsPlayerFragment implements SlidingUpPa
         }
 
         @Override
-        public void updateCurrentSong(IndexedSong song) {
+        public void updateCurrentSong(@NonNull final Song song) {
             fragment.toolbar.setTitle(song.title);
             fragment.toolbar.setSubtitle(MusicUtil.getSongInfoString(song));
         }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/fragments/player/flat/FlatPlayerFragment.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/fragments/player/flat/FlatPlayerFragment.java
@@ -174,7 +174,6 @@ public class FlatPlayerFragment extends AbsPlayerFragment implements SlidingUpPa
         }
     }
 
-    @SuppressWarnings("ConstantConditions")
     private void updateCurrentSong() {
         impl.updateCurrentSong(MusicPlayerRemote.getCurrentSong());
 

--- a/app/src/main/java/com/poupa/vinylmusicplayer/util/MusicUtil.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/util/MusicUtil.java
@@ -130,7 +130,7 @@ public class MusicUtil {
     }
 
     @NonNull
-    public static String getPlaylistInfoString(@NonNull final Context context, @NonNull List<Song> songs) {
+    public static String getPlaylistInfoString(@NonNull final Context context, @NonNull List<? extends Song> songs) {
         final long duration = getTotalDuration(songs);
 
         return MusicUtil.buildInfoString(
@@ -156,7 +156,7 @@ public class MusicUtil {
         return year > 0 ? String.valueOf(year) : "-";
     }
 
-    public static long getTotalDuration(@NonNull List<Song> songs) {
+    public static long getTotalDuration(@NonNull List<? extends Song> songs) {
         long duration = 0;
         for (int i = 0; i < songs.size(); i++) {
             duration += songs.get(i).duration;

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -29,7 +29,7 @@
     <string name="action_save_playing_queue">Save playing queue</string>
     <string name="about_to_add_title_to_playing_queue">About to add 1 song into the playing queue.\nHow do you want to proceed with this song?</string>
     <string name="about_to_add_x_titles_to_playing_queue">About to add %1$d songs into the playing queue.\nHow do you want to proceed with these songs?</string>
-    <string name="added_title_to_playing_queue">"Added 1 songs to the playing queue."</string>
+    <string name="added_title_to_playing_queue">"Added 1 song to the playing queue."</string>
     <string name="added_x_titles_to_playing_queue">Added %1$d songs to the playing queue.</string>
     <string name="failed_restore_playing_queue">Cannot restore, previous queue is corrupted</string>
 

--- a/app/src/test/java/com/poupa/vinylmusicplayer/StaticPlayingQueueTest.java
+++ b/app/src/test/java/com/poupa/vinylmusicplayer/StaticPlayingQueueTest.java
@@ -1,20 +1,19 @@
 package com.poupa.vinylmusicplayer;
 
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
+import static junit.framework.TestCase.assertEquals;
 
 import com.poupa.vinylmusicplayer.misc.queue.IndexedSong;
 import com.poupa.vinylmusicplayer.misc.queue.StaticPlayingQueue;
 import com.poupa.vinylmusicplayer.model.Song;
 
-import org.junit.runners.JUnit4;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
-import static junit.framework.TestCase.assertEquals;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 
 @RunWith(JUnit4.class)
@@ -55,8 +54,6 @@ public class StaticPlayingQueueTest {
 
         test.addAll(list);
 
-        test.getPlayingQueueSongOnly(); //ensure songsIsStale is false before commencing the test
-
         return test;
     }
 
@@ -65,26 +62,6 @@ public class StaticPlayingQueueTest {
             IndexedSong song = test.getPlayingQueue().get(i);
 
             assertEquals(test.getOriginalPlayingQueue().get(song.index).title, song.title);
-        }
-    }
-
-    private void checkSongs(StaticPlayingQueue test) throws Exception {
-        List<Song> songs = test.getPlayingQueueSongOnly();
-
-        System.out.print("         queue: ");
-        System.out.println(Arrays.toString(test.getPlayingQueue().toArray()));
-
-        System.out.print("         songs: [");
-        for (int i = 0; i < test.size(); i++) {
-            System.out.print(songs.get(i).title+", ");
-        }
-        System.out.println("]");
-
-
-        for (int i = 0; i < test.size(); i++) {
-            IndexedSong song = test.getPlayingQueue().get(i);
-
-            assertEquals(song.title, songs.get(i).title);
         }
     }
 
@@ -106,7 +83,6 @@ public class StaticPlayingQueueTest {
 
         assertEquals(0, test.getCurrentPosition());
         checkQueuePosition(test);
-        checkSongs(test);
 
         System.out.println("Shuffle 2");
         test.setShuffle(StaticPlayingQueue.SHUFFLE_MODE_NONE);
@@ -114,7 +90,6 @@ public class StaticPlayingQueueTest {
 
         assertEquals(init.getCurrentPosition(), test.getCurrentPosition());
         checkQueuePosition(test);
-        checkSongs(test);
 
         assertEquals(init.getPlayingQueue().toString(), test.getPlayingQueue().toString());
     }
@@ -136,7 +111,6 @@ public class StaticPlayingQueueTest {
         print(test);
 
         checkQueuePosition(test);
-        checkSongs(test);
     }
 
     @Test
@@ -157,7 +131,6 @@ public class StaticPlayingQueueTest {
         print(test);
 
         checkQueuePosition(test);
-        checkSongs(test);
     }
 
     @Test
@@ -183,7 +156,6 @@ public class StaticPlayingQueueTest {
         print(test);
 
         checkQueuePosition(test);
-        checkSongs(test);
         assertEquals(init.getPlayingQueue().toString(), test.getPlayingQueue().toString());
     }
 
@@ -212,7 +184,6 @@ public class StaticPlayingQueueTest {
         print(test);
 
         checkQueuePosition(test);
-        checkSongs(test);
     }
 
     @Test
@@ -241,7 +212,6 @@ public class StaticPlayingQueueTest {
         print(test);
 
         checkQueuePosition(test);
-        checkSongs(test);
     }
 
     @Test
@@ -265,7 +235,6 @@ public class StaticPlayingQueueTest {
         print(test);
 
         checkQueuePosition(test);
-        checkSongs(test);
     }
 
     @Test
@@ -284,7 +253,6 @@ public class StaticPlayingQueueTest {
         print(test);
 
         checkQueuePosition(test);
-        checkSongs(test);
 
         System.out.println("Shuffle");
         test.setShuffle(StaticPlayingQueue.SHUFFLE_MODE_SHUFFLE);
@@ -295,7 +263,6 @@ public class StaticPlayingQueueTest {
         print(test);
 
         checkQueuePosition(test);
-        checkSongs(test);
     }
 
     @Test
@@ -318,7 +285,6 @@ public class StaticPlayingQueueTest {
         print(test);
 
         checkQueuePosition(test);
-        checkSongs(test);
     }
 
     @Test
@@ -344,7 +310,6 @@ public class StaticPlayingQueueTest {
 
         assertEquals(true, hasPositionChanged);
         checkQueuePosition(test);
-        checkSongs(test);
     }
 
     @Test
@@ -370,6 +335,5 @@ public class StaticPlayingQueueTest {
 
         assertEquals(false, hasPositionChanged);
         checkQueuePosition(test);
-        checkSongs(test);
     }
 }


### PR DESCRIPTION
Fixes #936 

This is quite a big change, involving the introduction of unique and stable ID for each song in a static playlist (on the same idea that @Octoton implemented on the playing queue with the `IndexedSong` class).

To support this, I needed to change the API of multiple classes, from using `ArrayList<Song>` to `List<? extends Song>`.

I took the opportunity to do some cleanup and limited the concept of `IndexedSong` to only where it's necessary.

--

Note that with this PR, if one select a duplicated item in a playlist, both copies will be selected. Any subsequent action on the selection (i.e. remove from playlist) will be applied to all the dupes (i.e. all occurence of the selected song will be removed). 

Quite counter-intuitive for me. 

Another PR (with important refactoring on the handling of multi-select in the case of dupe) will be proposed to handle this part. Relevant code are in https://github.com/VinylMusicPlayer/VinylMusicPlayer/tree/refactor-multi-select