### PR TITLE
Keep the queue in sync with changes from MediaStore (removal, update)

### DIFF
--- a/app/src/main/java/com/poupa/vinylmusicplayer/helper/MusicPlayerRemote.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/helper/MusicPlayerRemote.java
@@ -119,11 +119,6 @@ public class MusicPlayerRemote {
         }
     }
 
-    public static void onMediaStoreChanged() {
-        if (musicService != null) {
-            musicService.onMediaStoreChanged();
-        }
-    }
     /**
      * Async
      */

--- a/app/src/main/java/com/poupa/vinylmusicplayer/helper/MusicPlayerRemote.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/helper/MusicPlayerRemote.java
@@ -119,6 +119,11 @@ public class MusicPlayerRemote {
         }
     }
 
+    public static void onMediaStoreChanged() {
+        if (musicService != null) {
+            musicService.onMediaStoreChanged();
+        }
+    }
     /**
      * Async
      */
@@ -367,7 +372,7 @@ public class MusicPlayerRemote {
         }
     }
 
-    public static void setShuffleMode(final int shuffleMode) {
+    private static void setShuffleMode(final int shuffleMode) {
         if (musicService != null) {
             musicService.setShuffleMode(shuffleMode);
         }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/misc/queue/StaticPlayingQueue.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/misc/queue/StaticPlayingQueue.java
@@ -44,6 +44,13 @@ public class StaticPlayingQueue {
     }
 
     public StaticPlayingQueue(ArrayList<IndexedSong> restoreQueue, ArrayList<IndexedSong> restoreOriginalQueue, int restoredPosition, int shuffleMode, int repeatMode) {
+        if (restoreQueue.size() != restoreOriginalQueue.size()) {
+            throw new IllegalArgumentException("Mismatching queue size: queue=" + restoreQueue.size() + " vs originalQueue=" + restoreOriginalQueue.size());
+        }
+        if (restoredPosition < 0 || restoredPosition > restoreQueue.size() - 1) {
+            throw new IllegalArgumentException("Queue size=" + restoreQueue.size() + " vs position=" + restoredPosition);
+        }
+
         this.queue = new ArrayList<>(restoreQueue);
         this.originalQueue = new ArrayList<>(restoreOriginalQueue);
         this.shuffleMode = shuffleMode;

--- a/app/src/main/java/com/poupa/vinylmusicplayer/model/smartplaylist/AbsSmartPlaylist.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/model/smartplaylist/AbsSmartPlaylist.java
@@ -36,7 +36,7 @@ public abstract class AbsSmartPlaylist extends AbsCustomPlaylist {
     public boolean canImport() {return false;}
 
     public void importPlaylist(@NonNull Context context, @NonNull Playlist playlist) {
-        // Notify app of clear event, so that the smart playlists are refreshed
+        // Notify app of the event, so that the smart playlists are refreshed
         if (canImport()) context.sendBroadcast(new Intent(MusicService.META_CHANGED));
     }
 

--- a/app/src/main/java/com/poupa/vinylmusicplayer/service/MusicService.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/service/MusicService.java
@@ -125,7 +125,6 @@ public class MusicService extends MediaBrowserServiceCompat implements SharedPre
     static final int FOCUS_CHANGE = 6;
     static final int DUCK = 7;
     static final int UNDUCK = 8;
-    static final int RESTORE_QUEUES = 9;
 
     public static final int RANDOM_START_POSITION_ON_SHUFFLE = StaticPlayingQueue.INVALID_POSITION;
     public static final int SHUFFLE_MODE_NONE = StaticPlayingQueue.SHUFFLE_MODE_NONE;
@@ -135,7 +134,6 @@ public class MusicService extends MediaBrowserServiceCompat implements SharedPre
     public static final int REPEAT_MODE_ALL = StaticPlayingQueue.REPEAT_MODE_ALL;
     public static final int REPEAT_MODE_THIS = StaticPlayingQueue.REPEAT_MODE_THIS;
 
-    static final int SAVE_QUEUES = 0;
     private static final int SKIP_THRESHOLD_MS = 5000;
 
     @RequiresApi(Build.VERSION_CODES.O)
@@ -419,8 +417,8 @@ public class MusicService extends MediaBrowserServiceCompat implements SharedPre
     }
 
     private void saveQueues() {
-        queueSaveHandler.removeMessages(SAVE_QUEUES);
-        queueSaveHandler.sendEmptyMessage(SAVE_QUEUES);
+        queueSaveHandler.removeMessages(QueueSaveHandler.SAVE_QUEUES);
+        queueSaveHandler.sendEmptyMessage(QueueSaveHandler.SAVE_QUEUES);
     }
 
     private void restoreState() {
@@ -430,9 +428,9 @@ public class MusicService extends MediaBrowserServiceCompat implements SharedPre
         synchronized (this) {
             playingQueue.restoreMode(shuffleMode, repeateMode);
 
-            if (playbackHandlerThread.isAlive()) {
-                playbackHandler.removeMessages(RESTORE_QUEUES);
-                playbackHandler.sendEmptyMessage(RESTORE_QUEUES);
+            if (queueSaveHandlerThread.isAlive()) {
+                queueSaveHandler.removeMessages(QueueSaveHandler.RESTORE_QUEUES);
+                queueSaveHandler.sendEmptyMessage(QueueSaveHandler.RESTORE_QUEUES);
             }
         }
 
@@ -449,7 +447,7 @@ public class MusicService extends MediaBrowserServiceCompat implements SharedPre
         }
     }
 
-    private void restoreQueuesAndPosition() {
+    void restoreQueuesAndPosition() {
         synchronized (this) {
             try {
                 // The current playing song
@@ -1394,11 +1392,8 @@ public class MusicService extends MediaBrowserServiceCompat implements SharedPre
             // reload the queues so that they reflects the latest change
             // TODO We run into this code even when a playlist is added/modified -> Find a way to filter that event
 
-            saveQueuesImpl(); // synchronous save
-            savePosition();
-            savePositionInTrack();
-
-            restoreQueuesAndPosition();
+            saveState();
+            restoreState();
         }
     }
 }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/service/MusicService.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/service/MusicService.java
@@ -481,11 +481,6 @@ public class MusicService extends MediaBrowserServiceCompat implements SharedPre
                 // This prevents changing the player state, as it will stop the playback
                 final long currentSongId = getCurrentSong().id;
                 if (currentSongId != savedSongId) {
-                    SafeToast.show(this, "Song changed" +
-                            " previous=" + savedSongId +
-                            " vs now=" + currentSongId
-                    );
-
                     if (openCurrent() && (restoredPositionInTrack > 0)) {
                         seek(restoredPositionInTrack);
                     }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/service/MusicService.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/service/MusicService.java
@@ -1382,12 +1382,15 @@ public class MusicService extends MediaBrowserServiceCompat implements SharedPre
 
     public void onMediaStoreChanged() {
         // If a song is removed from the MediaStore, or updated (tags edited)
-        // force reload the queues so that they reflects the latest change
+        // reload the queues so that they reflects the latest change
+        // TODO We run into this code even when a playlist is added/modified -> Find a way to filter that event
 
         saveQueuesImpl(); // synchronous save
         savePosition();
         savePositionInTrack();
 
-        restoreQueuesAndPosition();
+        final boolean wasPlaying = isPlaying();
+        restoreQueuesAndPosition(); // TODO This will update the player, hence stops playing
+        if (wasPlaying) {play();}
     }
 }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/service/MusicService.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/service/MusicService.java
@@ -1381,16 +1381,19 @@ public class MusicService extends MediaBrowserServiceCompat implements SharedPre
     }
 
     public void onMediaStoreChanged() {
-        // If a song is removed from the MediaStore, or updated (tags edited)
-        // reload the queues so that they reflects the latest change
-        // TODO We run into this code even when a playlist is added/modified -> Find a way to filter that event
+        final boolean resync = false; // TODO Feature toggle, get from settings
+        if (resync) {
+            // If a song is removed from the MediaStore, or updated (tags edited)
+            // reload the queues so that they reflects the latest change
+            // TODO We run into this code even when a playlist is added/modified -> Find a way to filter that event
 
-        saveQueuesImpl(); // synchronous save
-        savePosition();
-        savePositionInTrack();
+            saveQueuesImpl(); // synchronous save
+            savePosition();
+            savePositionInTrack();
 
-        final boolean wasPlaying = isPlaying();
-        restoreQueuesAndPosition(); // TODO This will update the player, hence stops playing
-        if (wasPlaying) {play();}
+            final boolean wasPlaying = isPlaying();
+            restoreQueuesAndPosition(); // TODO This will update the player, hence stops playing
+            if (wasPlaying) {play();}
+        }
     }
 }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/service/MusicService.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/service/MusicService.java
@@ -1388,7 +1388,7 @@ public class MusicService extends MediaBrowserServiceCompat implements SharedPre
     }
 
     public void onMediaStoreChanged() {
-        final boolean resync = false; // TODO Feature toggle, get from settings
+        final boolean resync = PreferenceUtil.getInstance().isQueueSyncWithMediaStoreEnabled();
         if (resync) {
             // If a song is removed from the MediaStore, or updated (tags edited)
             // reload the queues so that they reflects the latest change

--- a/app/src/main/java/com/poupa/vinylmusicplayer/service/MusicService.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/service/MusicService.java
@@ -72,6 +72,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Random;
+import java.util.function.Function;
 
 /**
  * @author Karim Abou Zeid (kabouzeid), Andrew Neal
@@ -481,20 +482,26 @@ public class MusicService extends MediaBrowserServiceCompat implements SharedPre
                 final var currentSong = getCurrentSong();
                 if (!currentSong.isQuickEqual(savedCurrentSong)) {
                     // TODO For debug only
+                    Function<Song, String> songInfo = song -> String.format(
+                            "%d/'%s'",
+                            (song.id % 10000),
+                            song.title.substring(0, Math.min(song.title.length(), 10))
+                    );
                     SafeToast.show(this, "Song changed: " +
-                            "previous=" + savedCurrentSong.id + "/'" + savedCurrentSong.title  + "'" +
-                            " vs now=" + currentSong.id + "/'" + currentSong.title + "'");
+                            "previous=" + songInfo.apply(savedCurrentSong) +
+                            " vs now=" + songInfo.apply(currentSong)
+                    );
 
                     if (openCurrent() && (restoredPositionInTrack > 0)) {
                         seek(restoredPositionInTrack);
                     }
                     notHandledMetaChangedForCurrentTrack = true;
                     sendChangeInternal(META_CHANGED);
-                } // else just continue the playback till end of the song
 
-                // Restore playback
-                // TODO Unclear why the playback sometime is interrupted - not reproducible consistently
-                if (savedPlayingState && !isPlaying()) {play();}
+                    // Restore playback
+                    // TODO Unclear why the playback sometime is interrupted - not reproducible consistently
+                    if (savedPlayingState && !isPlaying()) {play();}
+                } // else just leave the playback with the current song
 
                 prepareNext();
                 sendChangeInternal(QUEUE_CHANGED);

--- a/app/src/main/java/com/poupa/vinylmusicplayer/service/PlaybackHandler.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/service/PlaybackHandler.java
@@ -91,10 +91,6 @@ final class PlaybackHandler extends Handler {
                 service.prepareNextImpl();
                 break;
 
-            case MusicService.RESTORE_QUEUES:
-                service.restoreQueuesAndPositionIfNecessary();
-                break;
-
             case MusicService.FOCUS_CHANGE:
                 switch (msg.arg1) {
                     case AudioManager.AUDIOFOCUS_GAIN:

--- a/app/src/main/java/com/poupa/vinylmusicplayer/service/QueueSaveHandler.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/service/QueueSaveHandler.java
@@ -9,6 +9,9 @@ import androidx.annotation.NonNull;
 import java.lang.ref.WeakReference;
 
 class QueueSaveHandler extends Handler {
+    static final int SAVE_QUEUES = 0;
+    static final int RESTORE_QUEUES = 1;
+
     @NonNull
     private final WeakReference<MusicService> mService;
 
@@ -20,8 +23,9 @@ class QueueSaveHandler extends Handler {
     @Override
     public void handleMessage(@NonNull Message msg) {
         final MusicService service = mService.get();
-        if (msg.what == MusicService.SAVE_QUEUES) {
-            service.saveQueuesImpl();
+        switch (msg.what) {
+            case SAVE_QUEUES -> service.saveQueuesImpl();
+            case RESTORE_QUEUES -> service.restoreQueuesAndPosition();
         }
     }
 }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/fragments/player/card/CardPlayerFragment.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/fragments/player/card/CardPlayerFragment.java
@@ -159,7 +159,6 @@ public class CardPlayerFragment extends AbsPlayerFragment implements SlidingUpPa
 
     @Override
     public void onMediaStoreChanged() {
-        MusicPlayerRemote.onMediaStoreChanged();
         updateQueue();
     }
 

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/fragments/player/card/CardPlayerFragment.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/fragments/player/card/CardPlayerFragment.java
@@ -159,8 +159,9 @@ public class CardPlayerFragment extends AbsPlayerFragment implements SlidingUpPa
 
     @Override
     public void onMediaStoreChanged() {
-        // TODO If a song is removed from the MediaStore, this is not reflected in the playing queue until restart
+        // TODO If a song is removed from the MediaStore, this is not reflected in the playing queue untill restart
         // TODO If a song is updated (tags edited), this is not reflected in the playing queue until restart
+        MusicPlayerRemote.onMediaStoreChanged();
         updateQueue();
     }
 

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/fragments/player/card/CardPlayerFragment.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/fragments/player/card/CardPlayerFragment.java
@@ -159,8 +159,6 @@ public class CardPlayerFragment extends AbsPlayerFragment implements SlidingUpPa
 
     @Override
     public void onMediaStoreChanged() {
-        // TODO If a song is removed from the MediaStore, this is not reflected in the playing queue untill restart
-        // TODO If a song is updated (tags edited), this is not reflected in the playing queue until restart
         MusicPlayerRemote.onMediaStoreChanged();
         updateQueue();
     }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/fragments/player/card/CardPlayerFragment.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/fragments/player/card/CardPlayerFragment.java
@@ -156,12 +156,6 @@ public class CardPlayerFragment extends AbsPlayerFragment implements SlidingUpPa
     public void onQueueChanged() {
         updateQueue();
     }
-
-    @Override
-    public void onMediaStoreChanged() {
-        updateQueue();
-    }
-
     private void updateQueue() {
         playingQueueAdapter.swapDataSet(MusicPlayerRemote.getPlayingQueue(), MusicPlayerRemote.getPosition());
         playerQueueSubHeader.setText(MusicPlayerRemote.getQueueInfoString());

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/fragments/player/flat/FlatPlayerFragment.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/fragments/player/flat/FlatPlayerFragment.java
@@ -153,7 +153,6 @@ public class FlatPlayerFragment extends AbsPlayerFragment implements SlidingUpPa
 
     @Override
     public void onMediaStoreChanged() {
-        MusicPlayerRemote.onMediaStoreChanged();
         updateQueue();
     }
 

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/fragments/player/flat/FlatPlayerFragment.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/fragments/player/flat/FlatPlayerFragment.java
@@ -151,11 +151,6 @@ public class FlatPlayerFragment extends AbsPlayerFragment implements SlidingUpPa
         updateQueue();
     }
 
-    @Override
-    public void onMediaStoreChanged() {
-        updateQueue();
-    }
-
     private void updateQueue() {
         playingQueueAdapter.swapDataSet(MusicPlayerRemote.getPlayingQueue(), MusicPlayerRemote.getPosition());
         playerQueueSubHeader.setText(MusicPlayerRemote.getQueueInfoString());

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/fragments/player/flat/FlatPlayerFragment.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/fragments/player/flat/FlatPlayerFragment.java
@@ -153,8 +153,7 @@ public class FlatPlayerFragment extends AbsPlayerFragment implements SlidingUpPa
 
     @Override
     public void onMediaStoreChanged() {
-        // TODO If a song is removed from the MediaStore, this is not reflected in the playing queue untill restart
-        // TODO If a song is updated (tags edited), this is not reflected in the playing queue until restart
+        MusicPlayerRemote.onMediaStoreChanged();
         updateQueue();
     }
 

--- a/app/src/main/java/com/poupa/vinylmusicplayer/util/PreferenceUtil.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/util/PreferenceUtil.java
@@ -30,7 +30,6 @@ import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Comparator;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -144,6 +143,8 @@ public final class PreferenceUtil {
 
     public static final String OOPS_HANDLER_ENABLED = "oops_handler_enabled";
     public static final String OOPS_HANDLER_EXCEPTIONS = "oops_handler_exceptions";
+
+    public static final String QUEUE_SYNC_MEDIA_STORE_ENABLED = "queue_sync_with_media_store";
 
     private static PreferenceUtil sInstance;
 
@@ -845,5 +846,9 @@ public final class PreferenceUtil {
         mPreferences.edit()
                 .putInt(ENQUEUE_SONGS_DEFAULT_CHOICE, choice)
                 .apply();
+    }
+
+    public boolean isQueueSyncWithMediaStoreEnabled() {
+        return mPreferences.getBoolean(QUEUE_SYNC_MEDIA_STORE_ENABLED, false);
     }
 }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/util/SafeToast.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/util/SafeToast.java
@@ -13,7 +13,7 @@ import androidx.annotation.StringRes;
  * Toast wrapper that can be used from non-UI thread
  */
 public class SafeToast {
-    private static final int DURATION = Toast.LENGTH_SHORT;
+    private static final int DURATION = Toast.LENGTH_LONG;
 
     public static void show(@NonNull final Context context, @StringRes final int resId)
             throws Resources.NotFoundException {

--- a/app/src/main/java/com/poupa/vinylmusicplayer/util/SafeToast.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/util/SafeToast.java
@@ -13,7 +13,7 @@ import androidx.annotation.StringRes;
  * Toast wrapper that can be used from non-UI thread
  */
 public class SafeToast {
-    private static final int DURATION = Toast.LENGTH_LONG;
+    private static final int DURATION = Toast.LENGTH_SHORT;
 
     public static void show(@NonNull final Context context, @StringRes final int resId)
             throws Resources.NotFoundException {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -198,6 +198,7 @@
     <string name="pref_summary_remember_shuffle">Shuffle mode will stay on when selecting a new list of songs</string>
     <string name="pref_title_oops_handler_enabled">Collect crash reports</string>
     <string name="pref_summary_oops_handler_enabled">Help development by collecting and reporting crashes</string>
+    <string name="pref_title_queue_sync_with_media_store">Sync queue with media tag updates</string>
     <string name="could_not_download_album_cover">"Couldn\u2019t download a matching album cover."</string>
     <string name="search_hint">Search your library…</string>
     <string name="favorites">Favorites</string>

--- a/app/src/main/res/xml/pref_development.xml
+++ b/app/src/main/res/xml/pref_development.xml
@@ -10,6 +10,12 @@
             android:summary="@string/pref_summary_oops_handler_enabled"
             android:title="@string/pref_title_oops_handler_enabled" />
 
+        <com.kabouzeid.appthemehelper.common.prefs.supportv7.ATESwitchPreference
+            app:iconSpaceReserved="false"
+            android:defaultValue="false"
+            android:key="queue_sync_with_media_store"
+            android:title="@string/pref_title_queue_sync_with_media_store" />
+
     </com.kabouzeid.appthemehelper.common.prefs.supportv7.ATEPreferenceCategory>
 
 </androidx.preference.PreferenceScreen>


### PR DESCRIPTION
This new feature for now is controlled by an opt-in flag in Settings.
I'll enable by default/remove the flag in the future if no negative user feedback.

To dos:
- [x] Sometime, when the library is updated, the current playback is paused.