### PR TITLE
Next release 1.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,15 @@
 # Changelog
+
 ## [1.8.1] - 2024-03-04
 
 ### Fixes
 * Fix save playlist android9 by @soncaokim in https://github.com/VinylMusicPlayer/VinylMusicPlayer/pull/944
-* Dangling unknown artist by @soncaokim in https://github.com/VinylMusicPlayer/VinylMusicPlayer/pull/956
+* Fix dangling unknown artist by @soncaokim in https://github.com/VinylMusicPlayer/VinylMusicPlayer/pull/956
 * Fix crash on select dupe song in playlist by @soncaokim in https://github.com/VinylMusicPlayer/VinylMusicPlayer/pull/950
-* Restore previous code to maintain compat with different version of Android by @soncaokim in https://github.com/VinylMusicPlayer/VinylMusicPlayer/pull/968
-* Attempt to fix stale notification by @soncaokim in https://github.com/VinylMusicPlayer/VinylMusicPlayer/pull/961
-### Other Changes
-* Upgrade to gradle 8.2 by @soncaokim in https://github.com/VinylMusicPlayer/VinylMusicPlayer/pull/941
-* Revert gradle-8.2 upgrade by @soncaokim in https://github.com/VinylMusicPlayer/VinylMusicPlayer/pull/955
+* Fix stale notification by @soncaokim in https://github.com/VinylMusicPlayer/VinylMusicPlayer/pull/961
 * Silence logcat warning about deprecated use of stream type by @soncaokim in https://github.com/VinylMusicPlayer/VinylMusicPlayer/pull/963
+
+### Other Changes
 
 **Full Changelog**: https://github.com/VinylMusicPlayer/VinylMusicPlayer/compare/1.8.0...1.8.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,18 @@
 # Changelog
+## [1.8.1] - 2024-03-04
+
+### Fixes
+* Fix save playlist android9 by @soncaokim in https://github.com/VinylMusicPlayer/VinylMusicPlayer/pull/944
+* Dangling unknown artist by @soncaokim in https://github.com/VinylMusicPlayer/VinylMusicPlayer/pull/956
+* Fix crash on select dupe song in playlist by @soncaokim in https://github.com/VinylMusicPlayer/VinylMusicPlayer/pull/950
+* Restore previous code to maintain compat with different version of Android by @soncaokim in https://github.com/VinylMusicPlayer/VinylMusicPlayer/pull/968
+* Attempt to fix stale notification by @soncaokim in https://github.com/VinylMusicPlayer/VinylMusicPlayer/pull/961
+### Other Changes
+* Upgrade to gradle 8.2 by @soncaokim in https://github.com/VinylMusicPlayer/VinylMusicPlayer/pull/941
+* Revert gradle-8.2 upgrade by @soncaokim in https://github.com/VinylMusicPlayer/VinylMusicPlayer/pull/955
+* Silence logcat warning about deprecated use of stream type by @soncaokim in https://github.com/VinylMusicPlayer/VinylMusicPlayer/pull/963
+
+**Full Changelog**: https://github.com/VinylMusicPlayer/VinylMusicPlayer/compare/1.8.0...1.8.1
 
 ## [1.8.0] - 2024-02-08
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -43,8 +43,8 @@ android {
         vectorDrawables.useSupportLibrary = true
 
         applicationId 'com.poupa.vinylmusicplayer'
-        versionCode 191
-        versionName '1.8.0'
+        versionCode 192
+        versionName '1.8.1'
 
         multiDexEnabled true
     }

--- a/app/src/main/assets/contributors.csv
+++ b/app/src/main/assets/contributors.csv
@@ -1,4 +1,4 @@
-"soncaokim","https://avatars.githubusercontent.com/u/13333482?v=4","https://github.com/soncaokim",1135
+"soncaokim","https://avatars.githubusercontent.com/u/13333482?v=4","https://github.com/soncaokim",1169
 "kabouzeid","https://avatars.githubusercontent.com/u/7303830?v=4","https://github.com/kabouzeid",1095
 "AdrienPoupa","https://avatars.githubusercontent.com/u/15086425?v=4","https://github.com/AdrienPoupa",280
 "Octoton","https://avatars.githubusercontent.com/u/56130419?v=4","https://github.com/Octoton",86


### PR DESCRIPTION
## [1.8.1] - 2024-03-04

### Fixes
* Fix save playlist android9 by @soncaokim in https://github.com/VinylMusicPlayer/VinylMusicPlayer/pull/944
* Fix dangling unknown artist by @soncaokim in https://github.com/VinylMusicPlayer/VinylMusicPlayer/pull/956
* Fix crash on select dupe song in playlist by @soncaokim in https://github.com/VinylMusicPlayer/VinylMusicPlayer/pull/950
* Fix stale notification by @soncaokim in https://github.com/VinylMusicPlayer/VinylMusicPlayer/pull/961
* Silence logcat warning about deprecated use of stream type by @soncaokim in https://github.com/VinylMusicPlayer/VinylMusicPlayer/pull/963

### Other Changes

**Full Changelog**: https://github.com/VinylMusicPlayer/VinylMusicPlayer/compare/1.8.0...1.8.1
