### PR TITLE
Resolve "Android 8: Unnecessary "Vinyl is running" notification #952"

### DIFF
--- a/app/src/main/java/com/poupa/vinylmusicplayer/service/notification/IdleNotification.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/service/notification/IdleNotification.java
@@ -1,28 +1,40 @@
 package com.poupa.vinylmusicplayer.service.notification;
 
 import android.app.Notification;
+import android.os.Build;
 
 import androidx.core.app.NotificationCompat;
 
 import com.poupa.vinylmusicplayer.R;
 
+/**
+ * This notification is added as part of Android 13 upgrade (required by Google). It shows up in
+ * place of the usual now-playing notification if nothing is playing, to indicate that the app is
+ * running in the background.
+ * See <a href="https://github.com/VinylMusicPlayer/VinylMusicPlayer/issues/952">#952</a> for
+ * further information.
+ */
 public class IdleNotification extends AbsNotification {
     private static final int NOTIFICATION_ID = 2;
     public static final String NOTIFICATION_CHANNEL_ID = "idle_notification";
 
     public void update() {
-        final Notification notification = new NotificationCompat.Builder(service, NOTIFICATION_CHANNEL_ID)
-                .setSmallIcon(R.drawable.ic_notification)
-                .setContentTitle(service.getString(R.string.idle_notification_title))
-                .setOngoing(true)
-                .setCategory(NotificationCompat.CATEGORY_SERVICE)
-                .setPriority(NotificationCompat.PRIORITY_LOW)
-                .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
-                .build();
-        service.startForeground(NOTIFICATION_ID, notification);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            final Notification notification = new NotificationCompat.Builder(service, NOTIFICATION_CHANNEL_ID)
+                    .setSmallIcon(R.drawable.ic_notification)
+                    .setContentTitle(service.getString(R.string.idle_notification_title))
+                    .setOngoing(true)
+                    .setCategory(NotificationCompat.CATEGORY_SERVICE)
+                    .setPriority(NotificationCompat.PRIORITY_LOW)
+                    .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
+                    .build();
+            service.startForeground(NOTIFICATION_ID, notification);
+        }
     }
 
     public void stop() {
-        notificationManager.cancel(NOTIFICATION_ID);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            notificationManager.cancel(NOTIFICATION_ID);
+        }
     }
 }


### PR DESCRIPTION
Closes #952

I chose this approach because it does not clutter `MusicService.java`, however the right approach probably would be to annotate `IdleNotification` with `@RequiresApi(Build.VERSION_CODES.TIRAMISU)` and add the necessary ifs in `MusicService.java`. I can do that too if desired.