### PR TITLE
Fallback to cover image scanned and stored in MediaStore

### DIFF
--- a/app/src/main/java/com/poupa/vinylmusicplayer/glide/audiocover/AbsCoverFetcher.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/glide/audiocover/AbsCoverFetcher.java
@@ -1,10 +1,31 @@
 package com.poupa.vinylmusicplayer.glide.audiocover;
 
+import android.content.ContentUris;
+import android.content.Context;
+import android.graphics.Bitmap;
+import android.graphics.Point;
+import android.net.Uri;
+import android.os.Build;
+import android.provider.MediaStore;
+import android.util.Size;
+
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.bumptech.glide.load.DataSource;
 import com.bumptech.glide.load.data.DataFetcher;
+import com.poupa.vinylmusicplayer.App;
+import com.poupa.vinylmusicplayer.model.Song;
+import com.poupa.vinylmusicplayer.util.AutoCloseAudioFile;
+import com.poupa.vinylmusicplayer.util.OopsHandler;
+import com.poupa.vinylmusicplayer.util.SAFUtil;
+import com.poupa.vinylmusicplayer.util.Util;
 
+import org.jaudiotagger.audio.AudioFile;
+import org.jaudiotagger.tag.images.Artwork;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -16,7 +37,7 @@ import java.io.InputStream;
  * @author SC (soncaokim)
  */
 public abstract class AbsCoverFetcher implements DataFetcher<InputStream> {
-    private FileInputStream stream;
+    private InputStream stream;
 
     @NonNull
     @Override
@@ -30,22 +51,79 @@ public abstract class AbsCoverFetcher implements DataFetcher<InputStream> {
         return DataSource.LOCAL;
     }
 
-    private static final String[] FALLBACKS =
-            {"cover.jpg", "album.jpg", "folder.jpg", "cover.png", "album.png", "folder.png"};
-
-    protected InputStream fallback(String path) throws FileNotFoundException {
-        return fallback(new File(path));
+    @Nullable
+    InputStream loadCoverFromAudioTags(@NonNull final Song song) {
+        try (final AutoCloseAudioFile audio = SAFUtil.loadReadOnlyAudioFile(App.getStaticContext(), song)) {
+            if (audio == null) {return null;}
+            return loadCoverFromAudioTags(audio.get());
+        } catch (final Exception e) {
+            OopsHandler.collectStackTrace(e);
+        }
+        return null;
     }
 
-    protected InputStream fallback(File file) throws FileNotFoundException {
-        // Look for album art in external files
-        File parent = file.getParentFile();
-        for (String fallback : FALLBACKS) {
-            File cover = new File(parent, fallback);
-            if (cover.exists()) {
-                return stream = new FileInputStream(cover);
+    @Nullable
+    InputStream loadCoverFromAudioTags(@NonNull final File file) {
+        try {
+            final AudioFile audio = SAFUtil.loadAudioFile(file);
+            if (audio == null) {return null;}
+            return loadCoverFromAudioTags(audio);
+        } catch (final Exception e) {
+            OopsHandler.collectStackTrace(e);
+        }
+        return null;
+    }
+
+    @Nullable
+    private InputStream loadCoverFromAudioTags(@NonNull final AudioFile audio) {
+        final Artwork art = audio.getTag().getFirstArtwork();
+        if (art != null) {
+            final byte[] imageData = art.getBinaryData();
+            return stream = new ByteArrayInputStream(imageData);
+        }
+        return null;
+    }
+
+    @Nullable
+    InputStream loadCoverFromMediaStore(@NonNull final Song song) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            final Uri uri = ContentUris.withAppendedId(MediaStore.Audio.Albums.EXTERNAL_CONTENT_URI, song.albumId);
+            try {
+                final Context context = App.getStaticContext();
+                final Point screenSize = Util.getScreenSize(context);
+                final int coverSize = Math.min(screenSize.x, screenSize.y);
+                final Bitmap cover = context.getContentResolver().loadThumbnail(uri, new Size(coverSize, coverSize), null);
+
+                // Hideous way to transfer the Bitmap data to an InputStream
+                ByteArrayOutputStream ostream = new ByteArrayOutputStream();
+                cover.compress(Bitmap.CompressFormat.JPEG, 100, ostream);
+                return stream = new ByteArrayInputStream(ostream.toByteArray());
+            } catch (final FileNotFoundException ignored) {
+                // No album
+            } catch (final IOException error) {
+                OopsHandler.collectStackTrace(error);
             }
         }
+        return null;
+    }
+
+    private static final String[] FOLDER_IMAGE_FALLBACKS = {
+            "cover.jpg", "album.jpg", "folder.jpg",
+            "cover.png", "album.png", "folder.png"
+    };
+
+    @Nullable
+    InputStream loadCoverFromFolderImage(@NonNull final File file) {
+        // Look for album art in external files
+        try {
+            final File parent = file.getParentFile();
+            for (final String fallback : FOLDER_IMAGE_FALLBACKS) {
+                final File cover = new File(parent, fallback);
+                if (cover.exists()) {
+                    return stream = new FileInputStream(cover);
+                }
+            }
+        } catch (final FileNotFoundException ignored) {}
         return null;
     }
 
@@ -55,7 +133,7 @@ public abstract class AbsCoverFetcher implements DataFetcher<InputStream> {
         if (stream != null) {
             try {
                 stream.close();
-            } catch (IOException ignore) {
+            } catch (final IOException ignore) {
                 // can't do much about it
             }
         }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/glide/audiocover/AbsCoverFetcher.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/glide/audiocover/AbsCoverFetcher.java
@@ -2,21 +2,26 @@ package com.poupa.vinylmusicplayer.glide.audiocover;
 
 import android.content.ContentUris;
 import android.content.Context;
+import android.database.Cursor;
 import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
 import android.graphics.Point;
 import android.net.Uri;
 import android.os.Build;
+import android.provider.BaseColumns;
 import android.provider.MediaStore;
 import android.util.Size;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
 
 import com.bumptech.glide.load.DataSource;
 import com.bumptech.glide.load.data.DataFetcher;
 import com.poupa.vinylmusicplayer.App;
 import com.poupa.vinylmusicplayer.model.Song;
 import com.poupa.vinylmusicplayer.util.AutoCloseAudioFile;
+import com.poupa.vinylmusicplayer.util.FileUtil;
 import com.poupa.vinylmusicplayer.util.OopsHandler;
 import com.poupa.vinylmusicplayer.util.SAFUtil;
 import com.poupa.vinylmusicplayer.util.Util;
@@ -31,6 +36,7 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.List;
 
 /**
  * @author Karim Abou Zeid (kabouzeid)
@@ -55,7 +61,9 @@ public abstract class AbsCoverFetcher implements DataFetcher<InputStream> {
     InputStream loadCoverFromAudioTags(@NonNull final Song song) {
         try (final AutoCloseAudioFile audio = SAFUtil.loadReadOnlyAudioFile(App.getStaticContext(), song)) {
             if (audio == null) {return null;}
-            return loadCoverFromAudioTags(audio.get());
+
+            stream = loadCoverFromAudioTags(audio.get());
+            return stream;
         } catch (final Exception e) {
             OopsHandler.collectStackTrace(e);
         }
@@ -67,7 +75,9 @@ public abstract class AbsCoverFetcher implements DataFetcher<InputStream> {
         try {
             final AudioFile audio = SAFUtil.loadAudioFile(file);
             if (audio == null) {return null;}
-            return loadCoverFromAudioTags(audio);
+
+            stream = loadCoverFromAudioTags(audio);
+            return stream;
         } catch (final Exception e) {
             OopsHandler.collectStackTrace(e);
         }
@@ -75,40 +85,93 @@ public abstract class AbsCoverFetcher implements DataFetcher<InputStream> {
     }
 
     @Nullable
-    private InputStream loadCoverFromAudioTags(@NonNull final AudioFile audio) {
+    private static InputStream loadCoverFromAudioTags(@NonNull final AudioFile audio) {
         final Artwork art = audio.getTag().getFirstArtwork();
         if (art != null) {
             final byte[] imageData = art.getBinaryData();
-            return stream = new ByteArrayInputStream(imageData);
+            return new ByteArrayInputStream(imageData);
         }
         return null;
     }
 
     @Nullable
     InputStream loadCoverFromMediaStore(@NonNull final Song song) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            final Uri uri = ContentUris.withAppendedId(MediaStore.Audio.Albums.EXTERNAL_CONTENT_URI, song.albumId);
-            try {
-                final Context context = App.getStaticContext();
-                final Point screenSize = Util.getScreenSize(context);
-                final int coverSize = Math.min(screenSize.x, screenSize.y);
-                final Bitmap cover = context.getContentResolver().loadThumbnail(uri, new Size(coverSize, coverSize), null);
-
-                // Hideous way to transfer the Bitmap data to an InputStream
-                ByteArrayOutputStream ostream = new ByteArrayOutputStream();
-                cover.compress(Bitmap.CompressFormat.JPEG, 100, ostream);
-                return stream = new ByteArrayInputStream(ostream.toByteArray());
-            } catch (final FileNotFoundException ignored) {
-                // No album
-            } catch (final IOException error) {
-                OopsHandler.collectStackTrace(error);
-            }
+        try {
+            final long albumId = song.albumId;
+            stream = (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q)
+                    ? loadCoverFromMediaStoreApi29(albumId)
+                    : loadCoverFromMediaStoreApi19(albumId);
+            return stream;
+        } catch (final Exception e) {
+            OopsHandler.collectStackTrace(e);
         }
         return null;
     }
 
+    @Nullable
+    InputStream loadCoverFromMediaStore(@NonNull final File file) {
+        final List<Song> matchingSongs = FileUtil.matchFilesWithMediaStore(List.of(file));
+        if (matchingSongs.size() != 1) {return null;} // non unique, abandon
+
+        final Song song = matchingSongs.get(0);
+        if (song.id == Song.EMPTY_SONG.id) {return null;} // not found, abandon
+
+        stream = loadCoverFromMediaStore(song);
+        return stream;
+    }
+
+    @RequiresApi(Build.VERSION_CODES.Q)
+    @Nullable
+    private static InputStream loadCoverFromMediaStoreApi29(final long albumId) throws IOException {
+        try {
+            final Uri uri = ContentUris.withAppendedId(MediaStore.Audio.Albums.EXTERNAL_CONTENT_URI, albumId);
+            final Context context = App.getStaticContext();
+            final Point screenSize = Util.getScreenSize(context);
+            final int coverSize = Math.min(screenSize.x, screenSize.y);
+            final Bitmap cover = context.getContentResolver().loadThumbnail(uri, new Size(coverSize, coverSize), null);
+
+            return bitmap2InputStream(cover);
+        } catch (final FileNotFoundException ignored) {}
+        return null;
+    }
+
+    @Nullable
+    private static InputStream loadCoverFromMediaStoreApi19(final long albumId) {
+        final Context context = App.getStaticContext();
+        try (final Cursor cursor = context.getContentResolver().query(
+                MediaStore.Audio.Albums.EXTERNAL_CONTENT_URI,
+                new String[] {BaseColumns._ID, MediaStore.Audio.AlbumColumns.ALBUM_ART},
+                BaseColumns._ID + " = " + albumId,
+                null,
+                null))
+        {
+            if (cursor == null) {return null;}
+
+            final int columnIndex = cursor.getColumnIndex(MediaStore.Audio.AlbumColumns.ALBUM_ART);
+            if (cursor.moveToNext()) {
+                final String path = cursor.getString(columnIndex);
+
+                final Bitmap cover = BitmapFactory.decodeFile(path);
+                if (cover == null) {return null;}
+
+                return bitmap2InputStream(cover);
+            }
+        }
+
+        return null;
+    }
+
+    @NonNull
+    private static InputStream bitmap2InputStream(@NonNull final Bitmap bitmap) {
+        // Hideous way to transfer the Bitmap data to an InputStream
+        final ByteArrayOutputStream ostream = new ByteArrayOutputStream();
+        bitmap.compress(Bitmap.CompressFormat.JPEG, 100, ostream);
+        return new ByteArrayInputStream(ostream.toByteArray());
+    }
+
     private static final String[] FOLDER_IMAGE_FALLBACKS = {
             "cover.jpg", "album.jpg", "folder.jpg",
+            "cover.jpeg", "album.jpeg", "folder.jpeg",
             "cover.png", "album.png", "folder.png"
     };
 
@@ -120,7 +183,8 @@ public abstract class AbsCoverFetcher implements DataFetcher<InputStream> {
             for (final String fallback : FOLDER_IMAGE_FALLBACKS) {
                 final File cover = new File(parent, fallback);
                 if (cover.exists()) {
-                    return stream = new FileInputStream(cover);
+                    stream = new FileInputStream(cover);
+                    return stream;
                 }
             }
         } catch (final FileNotFoundException ignored) {}

--- a/app/src/main/java/com/poupa/vinylmusicplayer/glide/audiocover/AbsCoverFetcher.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/glide/audiocover/AbsCoverFetcher.java
@@ -4,7 +4,6 @@ import android.content.ContentUris;
 import android.content.Context;
 import android.database.Cursor;
 import android.graphics.Bitmap;
-import android.graphics.BitmapFactory;
 import android.graphics.Point;
 import android.net.Uri;
 import android.os.Build;
@@ -136,7 +135,7 @@ public abstract class AbsCoverFetcher implements DataFetcher<InputStream> {
     }
 
     @Nullable
-    private static InputStream loadCoverFromMediaStoreApi19(final long albumId) {
+    private static InputStream loadCoverFromMediaStoreApi19(final long albumId) throws FileNotFoundException {
         final Context context = App.getStaticContext();
         try (final Cursor cursor = context.getContentResolver().query(
                 MediaStore.Audio.Albums.EXTERNAL_CONTENT_URI,
@@ -150,11 +149,9 @@ public abstract class AbsCoverFetcher implements DataFetcher<InputStream> {
             final int columnIndex = cursor.getColumnIndex(MediaStore.Audio.AlbumColumns.ALBUM_ART);
             if (cursor.moveToNext()) {
                 final String path = cursor.getString(columnIndex);
+                if (path == null) {return null;}
 
-                final Bitmap cover = BitmapFactory.decodeFile(path);
-                if (cover == null) {return null;}
-
-                return bitmap2InputStream(cover);
+                return new FileInputStream(path);
             }
         }
 

--- a/app/src/main/java/com/poupa/vinylmusicplayer/glide/audiocover/FileCoverFetcher.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/glide/audiocover/FileCoverFetcher.java
@@ -26,6 +26,9 @@ public class FileCoverFetcher extends AbsCoverFetcher {
             if (input == null) {
                 input = loadCoverFromFolderImage(model.file);
             }
+            if (input == null) {
+                input = loadCoverFromMediaStore(model.file);
+            }
 
             if (input == null) {
                 callback.onLoadFailed(new IOException("Cannot load cover for file"));

--- a/app/src/main/java/com/poupa/vinylmusicplayer/glide/audiocover/FileCoverFetcher.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/glide/audiocover/FileCoverFetcher.java
@@ -4,15 +4,9 @@ import androidx.annotation.NonNull;
 
 import com.bumptech.glide.Priority;
 import com.poupa.vinylmusicplayer.util.OopsHandler;
-import com.poupa.vinylmusicplayer.util.SAFUtil;
 
-import org.jaudiotagger.audio.AudioFile;
-import org.jaudiotagger.tag.images.Artwork;
-
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.MissingResourceException;
 
 /**
  * @author SC (soncaokim)
@@ -20,30 +14,25 @@ import java.util.MissingResourceException;
 public class FileCoverFetcher extends AbsCoverFetcher {
     private final FileCover model;
 
-    public FileCoverFetcher(FileCover model) {
+    FileCoverFetcher(@NonNull final FileCover value) {
         super();
-        this.model = model;
+        model = value;
     }
 
     @Override
-    public void loadData(@NonNull Priority priority, @NonNull DataCallback<? super InputStream> callback) {
+    public void loadData(@NonNull final Priority priority, @NonNull final DataCallback<? super InputStream> callback) {
         try {
-            final AudioFile audio = SAFUtil.loadAudioFile(model.file);
-            if (audio == null) {
-                callback.onLoadFailed(new IOException("Cannot load audio file"));
-                return;
+            InputStream input = loadCoverFromAudioTags(model.file);
+            if (input == null) {
+                input = loadCoverFromFolderImage(model.file);
             }
 
-            final Artwork art = audio.getTag().getFirstArtwork();
-            if (art != null) {
-                byte[] imageData = art.getBinaryData();
-                callback.onDataReady(new ByteArrayInputStream(imageData));
+            if (input == null) {
+                callback.onLoadFailed(new IOException("Cannot load cover for file"));
             } else {
-                InputStream data = fallback(model.file);
-                if (data != null) {callback.onDataReady(data);}
-                else {callback.onLoadFailed(new MissingResourceException("No artwork", "", ""));}
+                callback.onDataReady(input);
             }
-        } catch (Exception e) {
+        } catch (final Exception e) {
             OopsHandler.collectStackTrace(e);
             callback.onLoadFailed(e);
         }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/glide/audiocover/SongCoverFetcher.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/glide/audiocover/SongCoverFetcher.java
@@ -41,10 +41,10 @@ public class SongCoverFetcher extends AbsCoverFetcher {
     public InputStream loadData() {
         InputStream input = loadCoverFromAudioTags(model.song);
         if (input == null) {
-            input = loadCoverFromMediaStore(model.song);
+            input = loadCoverFromFolderImage(new File(model.song.data));
         }
         if (input == null) {
-            input = loadCoverFromFolderImage(new File(model.song.data));
+            input = loadCoverFromMediaStore(model.song);
         }
         return input;
     }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/glide/audiocover/SongCoverFetcher.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/glide/audiocover/SongCoverFetcher.java
@@ -41,10 +41,10 @@ public class SongCoverFetcher extends AbsCoverFetcher {
     public InputStream loadData() {
         InputStream input = loadCoverFromAudioTags(model.song);
         if (input == null) {
-            input = loadCoverFromFolderImage(new File(model.song.data));
+            input = loadCoverFromMediaStore(model.song);
         }
         if (input == null) {
-            input = loadCoverFromMediaStore(model.song);
+            input = loadCoverFromFolderImage(new File(model.song.data));
         }
         return input;
     }


### PR DESCRIPTION
Possibly fixes #816 on Android 13+, by relying on MediaStore to detect and scan the external folder image

Note that this is only a workaround, with limitations:
- [x] only for Android Q+
- [x] only work in Library view, not in Folder/SD Card views.