### PR TITLE
CI updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
     - name: Release to Play Store
       # TODO Dont publish to PlayStore any tag, must follow M.m.u convention
       if: (contains(github.ref, 'refs/tags/') && !contains(github.ref, 'refs/tags/pre-release'))
-      uses: r0adkll/upload-google-play@v1.1.2
+      uses: r0adkll/upload-google-play@v1.1.3
       with:
         serviceAccountJsonPlainText: ${{secrets.SERVICE_ACCOUNT}}
         packageName: com.poupa.vinylmusicplayer

--- a/script/build-release
+++ b/script/build-release
@@ -1,6 +1,11 @@
 #!/bin/bash
 
-echo "$KEYSTORE_PROPERTIES" > keystore.properties
-echo -n "$STORE_FILE" | base64 --decode > ./app/vinyl.jks
+# If the env variables are defined, use them as override to the signing config
+# This is to support CI/CD builds via Github Actions
+# Otherwise, rely on the default (unsecured) signing configs
+if [ -n "${KEYSTORE_PROPERTIES}" ]; then
+    echo "${KEYSTORE_PROPERTIES}" > keystore.properties
+    echo -n "{$STORE_FILE}" | base64 --decode > ./app/vinyl.jks
+fi
 
 ./gradlew $GRADLEW_COMMAND

--- a/script/build-release
+++ b/script/build-release
@@ -5,7 +5,7 @@
 # Otherwise, rely on the default (unsecured) signing configs
 if [ -n "${KEYSTORE_PROPERTIES}" ]; then
     echo "${KEYSTORE_PROPERTIES}" > keystore.properties
-    echo -n "{$STORE_FILE}" | base64 --decode > ./app/vinyl.jks
+    echo -n "${STORE_FILE}" | base64 --decode > ./app/vinyl.jks
 fi
 
 ./gradlew $GRADLEW_COMMAND


### PR DESCRIPTION
Two changes:
- Upgrade GH Actions plugin to comply with Node.js 16 deprecation
- Dont blindly overwrite the signing config if the app is built via GH Actions. Do this only if the signing config is effectively specified