### PR TITLE
Fix crash on Android 19 with go to artist

### DIFF
--- a/app/src/main/res/layout/activity_artist_detail.xml
+++ b/app/src/main/res/layout/activity_artist_detail.xml
@@ -198,7 +198,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
                     android:scaleType="centerCrop"
-                    android:src="@drawable/default_artist_image"
+                    app:srcCompat="@drawable/default_artist_image"
                     tools:ignore="ContentDescription" />
 
         </com.poupa.vinylmusicplayer.views.WidthFitSquareLayout>


### PR DESCRIPTION
Old Android doesnt support the vector drawable in XML
See https://developer.android.com/studio/write/vector-asset-studio