### PR TITLE
Fix crasher - when the device just started and the storage/mediastore is not ready

### DIFF
--- a/app/src/main/java/com/poupa/vinylmusicplayer/discog/MediaStoreBridge.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/discog/MediaStoreBridge.java
@@ -10,6 +10,7 @@ import androidx.annotation.Nullable;
 
 import com.poupa.vinylmusicplayer.discog.tagging.MultiValuesTagUtil;
 import com.poupa.vinylmusicplayer.model.Song;
+import com.poupa.vinylmusicplayer.util.OopsHandler;
 import com.poupa.vinylmusicplayer.util.PreferenceUtil;
 
 import java.util.ArrayList;
@@ -91,8 +92,8 @@ public class MediaStoreBridge {
                     null,
                     PreferenceUtil.getInstance().getSongSortOrder()
             );
-        } catch (SecurityException e) {
-            e.printStackTrace();
+        } catch (final RuntimeException e) {
+            OopsHandler.collectStackTrace(e);
             return null;
         }
     }


### PR DESCRIPTION
This bug is found using emulator with API 33. Fresh boot.