### PR TITLE
Always keep 'Favorites' playlist on top

### DIFF
--- a/app/src/main/java/com/poupa/vinylmusicplayer/provider/PreferencesBackedSongList.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/provider/PreferencesBackedSongList.java
@@ -7,6 +7,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.poupa.vinylmusicplayer.App;
+import com.poupa.vinylmusicplayer.R;
 import com.poupa.vinylmusicplayer.discog.Discography;
 import com.poupa.vinylmusicplayer.misc.queue.IndexedSong;
 import com.poupa.vinylmusicplayer.model.Song;
@@ -135,15 +136,25 @@ public class PreferencesBackedSongList extends MutableSongList {
     static List<PreferencesBackedSongList> loadAll() {
         ArrayList<PreferencesBackedSongList> result = new ArrayList<>();
 
+        String favoritesPlaylistName = App.getStaticContext().getString(R.string.favorites);
+        PreferencesBackedSongList favoritesPlaylist = null;
+
         final SharedPreferences preferences = getPreferences();
         for (String prefName : preferences.getAll().keySet()) {
             if (prefName.startsWith(PREF_NAME_PREFIX)) {
                 final String name = prefName.substring(PREF_NAME_PREFIX.length());
+                if (name.equals(favoritesPlaylistName)){
+                    favoritesPlaylist = new PreferencesBackedSongList(name);
+                    continue;
+                }
                 result.add(new PreferencesBackedSongList(name));
             }
         }
 
         Collections.sort(result, (l1, l2) -> StringUtil.compareIgnoreAccent(l1.name, l2.name));
+
+        if (favoritesPlaylist != null)
+            result.add(0, favoritesPlaylist);
 
         return result;
     }


### PR DESCRIPTION
Heeeey, how is it going?

I thought it would be a good idea to move 'Favorites' playlist on top of the 'Static playlists'. Now it lost somewhere in the middle and sometimes it is hard to find. 

Long story short:
![Screenshot_4_github](https://github.com/user-attachments/assets/5363aeed-0ad3-4dca-8206-a9935b0ed182)

Surely it's just an example of code, you know better how to implement this. In case you find it interesting. 

Thank you and keep up the good job!