### PR TITLE
Fix for #1109: Consider albums with no artists as well.

### DIFF
--- a/app/src/main/java/com/poupa/vinylmusicplayer/discog/MemCache.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/discog/MemCache.java
@@ -198,9 +198,14 @@ class MemCache {
         names.addAll(song.artistNames);
         names.addAll(song.albumArtistNames);
         final List<Artist> artists = new ArrayList<>(names.size());
-        for (final String name : names) {
-            final Artist artist = getOrCreateArtist.apply(name);
-            artists.add(artist);
+        if(names.isEmpty()){
+            // Albums must have an artist to be inserted into albumsByAlbumIdAndArtistId.
+            artists.add(Artist.EMPTY);
+        } else {
+            for (final String name : names) {
+                final Artist artist = getOrCreateArtist.apply(name);
+                artists.add(artist);
+            }
         }
 
         return artists;

--- a/app/src/test/java/com/poupa/vinylmusicplayer/discog/MemCacheTest.java
+++ b/app/src/test/java/com/poupa/vinylmusicplayer/discog/MemCacheTest.java
@@ -1,0 +1,38 @@
+package com.poupa.vinylmusicplayer.discog;
+
+import com.poupa.vinylmusicplayer.model.Song;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+import java.util.List;
+import java.util.Set;
+
+public class MemCacheTest {
+
+    @Test
+    public void addingSongWithNoArtist_albumStillShowsUp(){
+        MemCache memCache = new MemCache();
+
+        Song song1 = new Song(1, "NoArtists",   0, 0, 0, "---", 0, 0, 101, "Nice Songs 1", List.of());
+        Song song2 = new Song(1, "HasArtist",   0, 0, 0, "---", 0, 0, 102, "Nice Songs 2", List.of("A"));
+        Song song3 = new Song(1, "ManyArtists", 0, 0, 0, "---", 0, 0, 103, "Nice Songs 3", List.of("B","C"));
+
+        memCache.addSong(song1);
+        memCache.addSong(song2);
+        memCache.addSong(song3);
+
+        assertEquals(3, memCache.albumsByName.size());
+        assertEquals(Set.of(101L),memCache.albumsByName.get("Nice Songs 1"));
+        assertEquals(Set.of(102L),memCache.albumsByName.get("Nice Songs 2"));
+        assertEquals(Set.of(103L),memCache.albumsByName.get("Nice Songs 3"));
+        assertNull(memCache.albumsByName.get("D"));
+
+
+        assertEquals(3, memCache.albumsByAlbumIdAndArtistId.size());
+        assertNotNull(memCache.albumsByAlbumIdAndArtistId.get( 101L ));
+        assertNotNull(memCache.albumsByAlbumIdAndArtistId.get( 102L ));
+        assertNotNull(memCache.albumsByAlbumIdAndArtistId.get( 103L ));
+        assertNull(memCache.albumsByName.get("D"));
+    }
+}


### PR DESCRIPTION
## Fix for #1109 

When Vinyl adds a song to the `MemCache`, and the artist name list is empty,  the album ID was being inserted into `albumsByAlbumIdAndArtistId`, but no artists inside it. Then, empty albums were captured by `Discography.getAllAlbums`,  and they all used the same ID (`Album.safeGetFirstSong().albumId` == -1). 

The lines below, paired with the absence of any `Artist`s on the song is what ultimately caused the "Unknown Album" issue.
```      
if (albumsByArtist == null) {
    albumsByArtist = new HashMap<>();
    albumsByAlbumIdAndArtistId.put(song.albumId, albumsByArtist);
}
```

The unit test implemented corroborates this PR, and it would not pass with the current version of Vinyl.

So the error was not that the albums were invalid (and thus should have been delivered), but that these were **real albums** that should have been displayed.