### PR TITLE
Fix for issue #1132: Remove Debug Dialog and add Logging Call

### DIFF
--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/SettingsActivity.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/SettingsActivity.java
@@ -10,6 +10,7 @@ import android.media.audiofx.AudioEffect;
 import android.os.Build;
 import android.os.Bundle;
 import android.text.TextUtils;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.MenuItem;
 import android.view.View;
@@ -26,7 +27,6 @@ import androidx.preference.Preference;
 import androidx.preference.PreferenceManager;
 import androidx.preference.TwoStatePreference;
 
-import com.afollestad.materialdialogs.MaterialDialog;
 import com.afollestad.materialdialogs.color.ColorChooserDialog;
 import com.kabouzeid.appthemehelper.ThemeStore;
 import com.kabouzeid.appthemehelper.common.prefs.supportv7.ATEColorPreference;
@@ -98,16 +98,9 @@ public class SettingsActivity extends AbsBaseActivity implements ColorChooserDia
             if (frag != null) frag.invalidateSettings();
         }
 
-        // TODO Debug only
         final Collection<String> usedUndeclaredPrefKeys = PreferenceUtil.getInstance().getUndeclaredPrefKeys();
-        if (!usedUndeclaredPrefKeys.isEmpty()) {
-            new MaterialDialog.Builder(this)
-                    .title("Used but not declared pref keys")
-                    .items(usedUndeclaredPrefKeys)
-                    .autoDismiss(true)
-                    .positiveText(android.R.string.ok)
-                    .build()
-                    .show();
+        for(String prefKey : usedUndeclaredPrefKeys){
+            Log.i(this.getClass().getSimpleName(), "Used but not declared Pref Key: " + prefKey);
         }
     }
 


### PR DESCRIPTION
## Fix for #1132

Unused pref keys happen primarily when a new version of the app changes the name / stops using an Android Preference. These are some of the most recent (since 2023):

- `ignore_media_store_artwork` -- removed in 65cf71d7
- `blurred_album_art` -- removed in ecf0f6b6
- `album_art_on_lockscreen` -- also removed in ecf0f6b65
- `colored_app_shortcuts` --  was changed on d7de0ae98 to `should_color_app_shortcuts`.
- `make_widget_background_transparent` -- changed on d7de0ae98 to `should_make_widget_background_transparent`.

I strongly think that this popover should be changed to an Android logging call, since these old preferences are explainable and do not cause harm. Moreover, logging calls are also accessible for someone who wishes to debug the app.