### PR TITLE
Showing all External Storage Options in Blacklist view.

### DIFF
--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/MainActivity.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/MainActivity.java
@@ -46,6 +46,7 @@ import com.poupa.vinylmusicplayer.ui.activities.base.AbsSlidingMusicPanelActivit
 import com.poupa.vinylmusicplayer.ui.activities.intro.AppIntroActivity;
 import com.poupa.vinylmusicplayer.ui.fragments.mainactivity.folders.FoldersFragment;
 import com.poupa.vinylmusicplayer.ui.fragments.mainactivity.library.LibraryFragment;
+import com.poupa.vinylmusicplayer.util.FileUtil;
 import com.poupa.vinylmusicplayer.util.MusicUtil;
 import com.poupa.vinylmusicplayer.util.PreferenceUtil;
 import com.sothree.slidinguppanel.SlidingUpPanelLayout;
@@ -102,7 +103,7 @@ public class MainActivity extends AbsSlidingMusicPanelActivity implements Palett
                 setCurrentFragment(LibraryFragment.newInstance());
                 break;
             case SD_FOLDERS:
-                final File cardPath = FoldersFragment.getSDCardDirectory(this);
+                final File cardPath = FileUtil.getSDCardDirectory(this);
                 if (cardPath != null) {
                     navigationView.setCheckedItem(R.id.nav_sd_folders);
                     setCurrentFragment(FoldersFragment.newInstance(cardPath));
@@ -164,7 +165,7 @@ public class MainActivity extends AbsSlidingMusicPanelActivity implements Palett
         int accentColor = ThemeStore.accentColor(this);
         NavigationViewUtil.setItemIconColors(navigationView, ATHUtil.resolveColor(this, R.attr.iconColor, ThemeStore.textColorSecondary(this)), accentColor);
         NavigationViewUtil.setItemTextColors(navigationView, ThemeStore.textColorPrimary(this), accentColor);
-        if(FoldersFragment.getSDCardDirectory(this) != null){
+        if(FileUtil.getSDCardDirectory(this) != null){
             navigationView.getMenu().findItem(R.id.nav_sd_folders).setVisible(true);
         }
 

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/fragments/mainactivity/folders/FoldersFragment.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/fragments/mainactivity/folders/FoldersFragment.java
@@ -275,22 +275,6 @@ public class FoldersFragment
         return startFolder;
     }
 
-    public static File getSDCardDirectory(Context context) {
-        File sdFolder = null;
-        for (File dir : context.getExternalFilesDirs(null)) {
-            if(dir != null) {
-                if (!dir.equals(context.getExternalFilesDir(null))) {
-                    // first directory which is not primary storage - should be sd card
-                    String path = dir.getAbsolutePath();
-                    String base_path = path.substring(0, path.indexOf("Android/data"));
-                    sdFolder = new File(base_path);
-                    break;
-                }
-            }
-        }
-        return sdFolder;
-    }
-
     @Override
     public boolean onOptionsItemSelected(@NonNull final MenuItem item) {
         final int itemId = item.getItemId();


### PR DESCRIPTION
Fixes #1134 and #1028.

- Created method `getAllExternalStorageRootPaths`, to list all of the storage options available.
- When you navigate to the **root** folder in the Blacklist view, these are shown **alongside** the normally rendered options.

So this does not change the current app flow, and it's only visible when you are looking for other storage options.